### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"type": "git",
 		"url": "https://github.com/pento/testpress"
 	},
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
 		"@wordpress/hooks": "2.0.0",


### PR DESCRIPTION
**FIXES**

* Unable to run `npm install` on MacOS, as it required `/bin` to be in the path.