### PR TITLE
Attach the open dialog to the current window

### DIFF
--- a/src/components/preferences-panel/index.js
+++ b/src/components/preferences-panel/index.js
@@ -26,7 +26,7 @@ class PreferencesPanel extends Component {
 	}
 
 	showDirectorySelect( name ) {
-		remote.dialog.showOpenDialog( {
+		remote.dialog.showOpenDialog( remote.BrowserWindow.getFocusedWindow(), {
 				title: `Select ${ name } Folder`,
 				properties: [
 					'openDirectory',


### PR DESCRIPTION
This ensure the dialog sits above the window, which would otherwise render on top of everything.

Fixes #66.