### PR TITLE
Improve PHPUnit performance

### DIFF
--- a/src/services/docker/index.js
+++ b/src/services/docker/index.js
@@ -109,11 +109,13 @@ async function startDocker() {
 				volumes: [
 					'./phpunit-config.ini:/usr/local/etc/php/conf.d/phpunit-config.ini',
 					normalize( cwds[ 'wordpress-folder' ] ) + ':/wordpress-develop',
+					'phpunit-uploads:/wordpress-develop/src/wp-content/uploads',
 				],
 			},
 		},
 		volumes: {
 			mysql: {},
+			'phpunit-uploads': {},
 		},
 	};
 

--- a/src/services/docker/index.js
+++ b/src/services/docker/index.js
@@ -107,6 +107,7 @@ async function startDocker() {
 			phpunit: {
 				image: 'garypendergast/wordpress-develop-phpunit',
 				volumes: [
+					'./phpunit-config.ini:/usr/local/etc/php/conf.d/phpunit-config.ini',
 					normalize( cwds[ 'wordpress-folder' ] ) + ':/wordpress-develop',
 				],
 			},

--- a/src/services/docker/phpunit-config.ini
+++ b/src/services/docker/phpunit-config.ini
@@ -1,0 +1,6 @@
+upload_max_filesize = 1G
+post_max_size = 1G
+
+opcache.enable = 1
+opcache.enable_cli = 1
+opache.file_cache = /tmp/php-opcache


### PR DESCRIPTION
Enabling the opcache and moving the upload directory to an internal volume reduces the full test run time from 7 minutes to 3 minutes on my setup.