### PR TITLE
Add a UI for running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,84 +1,90 @@
 {
-	"name": "testpress",
-	"description": "An easy method for getting a WordPress Core test environment up and running.",
-	"author": "The WordPress Contributors",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/pento/testpress"
-	},
-	"version": "0.3.1",
-	"license": "GPL-2.0-or-later",
-	"dependencies": {
-		"@wordpress/hooks": "2.0.5",
-		"await-sleep": "0.0.1",
-		"chokidar": "2.1.2",
-		"compare-versions": "3.4.0",
-		"csvtojson": "2.0.8",
-		"debug": "4.1.1",
-		"decompress-zip": "0.3.2",
-		"electron-positioner": "4.1.0",
-		"electron-updater": "4.0.6",
-		"gridicons": "3.1.1",
-		"hasha": "3.0.0",
-		"hazardous": "0.3.0",
-		"intercept-stdout": "0.1.2",
-		"js-yaml": "3.12.1",
-		"node-fetch": "2.3.0",
-		"node-schedule": "1.3.2",
-		"promisepipe": "3.0.0",
-		"promisify-child-process": "3.1.0",
-		"react": "16.8.3",
-		"react-dom": "16.8.3",
-		"react-transition-group": "2.5.3",
-		"status-indicator": "1.0.9",
-		"strip-color": "0.1.0",
-		"tar": "4.4.8"
-	},
-	"homepage": "./",
-	"main": "src/electron-runner.js",
-	"scripts": {
-		"start": "npm run electron-start",
-		"dev": "cross-env DEBUG_COLORS=1 concurrently --kill-others \"npm run react-start\" \"wait-on http://localhost:3000/ && npm run electron-start\"",
-		"build": "react-scripts build",
-		"test": "react-scripts test --env=jsdom",
-		"eject": "react-scripts eject",
-		"electron-start": "cross-env ELECTRON_START_URL=http://localhost:3000/ electron .",
-		"react-start": "cross-env BROWSER=none NODE_ENV=development react-scripts start",
-		"pack": "electron-builder --dir",
-		"dist": "npm run build && electron-builder",
-		"publish": "npm run build && electron-builder --publish always",
-		"postinstall": "electron-builder install-app-deps"
-	},
-	"devDependencies": {
-		"concurrently": "4.1.0",
-		"cross-env": "5.2.0",
-		"electron": "4.0.5",
-		"electron-builder": "20.38.5",
-		"react-scripts": "2.1.5",
-		"wait-on": "3.2.0"
-	},
-	"build": {
-		"appId": "org.wordpress.testpress",
-		"productName": "TestPress",
-		"asarUnpack": [
-			"src/services/docker/default.conf"
-		],
-		"extends": null,
-		"files": [
-			"assets/**/*",
-			"build/**/*",
-			"node_modules/**/*",
-			"src/**/*"
-		],
-		"mac": {
-			"category": "public.app-category.developer-tools",
-			"icon": "assets/icon.png",
-			"extendInfo": {
-				"LSEnvironment": {
-					"PATH": "/usr/local/bin:/usr/bin:/bin"
-				}
-			},
-			"publish": "github"
-		}
-	}
+  "name": "testpress",
+  "description": "An easy method for getting a WordPress Core test environment up and running.",
+  "author": "The WordPress Contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pento/testpress"
+  },
+  "version": "0.3.1",
+  "license": "GPL-2.0-or-later",
+  "dependencies": {
+    "@wordpress/hooks": "2.0.5",
+    "await-sleep": "0.0.1",
+    "chokidar": "2.1.2",
+    "compare-versions": "3.4.0",
+    "csvtojson": "2.0.8",
+    "debug": "4.1.1",
+    "decompress-zip": "0.3.2",
+    "electron-positioner": "4.1.0",
+    "electron-updater": "4.0.6",
+    "gridicons": "3.1.1",
+    "hasha": "3.0.0",
+    "hazardous": "0.3.0",
+    "intercept-stdout": "0.1.2",
+    "js-yaml": "3.12.1",
+    "node-fetch": "2.3.0",
+    "node-schedule": "1.3.2",
+    "promisepipe": "3.0.0",
+    "promisify-child-process": "3.1.0",
+    "react": "16.8.3",
+    "react-dom": "16.8.3",
+    "react-transition-group": "2.5.3",
+    "status-indicator": "1.0.9",
+    "strip-color": "0.1.0",
+    "tar": "4.4.8"
+  },
+  "homepage": "./",
+  "main": "src/electron-runner.js",
+  "scripts": {
+    "start": "npm run electron-start",
+    "dev": "cross-env DEBUG_COLORS=1 concurrently --kill-others \"npm run react-start\" \"wait-on http://localhost:3000/ && npm run electron-start\"",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject",
+    "electron-start": "cross-env ELECTRON_START_URL=http://localhost:3000/ electron .",
+    "react-start": "cross-env BROWSER=none NODE_ENV=development react-scripts start",
+    "pack": "electron-builder --dir",
+    "dist": "npm run build && electron-builder",
+    "publish": "npm run build && electron-builder --publish always",
+    "postinstall": "electron-builder install-app-deps"
+  },
+  "devDependencies": {
+    "concurrently": "4.1.0",
+    "cross-env": "5.2.0",
+    "electron": "4.0.5",
+    "electron-builder": "20.38.5",
+    "react-scripts": "2.1.5",
+    "wait-on": "3.2.0"
+  },
+  "build": {
+    "appId": "org.wordpress.testpress",
+    "productName": "TestPress",
+    "asarUnpack": [
+      "src/services/docker/default.conf"
+    ],
+    "extends": null,
+    "files": [
+      "assets/**/*",
+      "build/**/*",
+      "node_modules/**/*",
+      "src/**/*"
+    ],
+    "mac": {
+      "category": "public.app-category.developer-tools",
+      "icon": "assets/icon.png",
+      "extendInfo": {
+        "LSEnvironment": {
+          "PATH": "/usr/local/bin:/usr/bin:/bin"
+        }
+      },
+      "publish": "github"
+    }
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
 }

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 
 import Pages from '../components/pages';
 import PreferencesPanel from '../components/preferences-panel';
+import TestPanel from '../components/test-panel';
 import StatusPanel from '../components/status-panel';
 import AboutPanel from '../components/about-panel';
 
@@ -14,6 +15,9 @@ class TestPress extends Component {
 		this.pages = [ {
 			heading: 'Welcome to TestPress',
 			panel: ( <StatusPanel /> ),
+		}, {
+			heading: 'Tests',
+			panel: ( <TestPanel /> ),
 		}, {
 			heading: 'Preferences',
 			panel: ( <PreferencesPanel /> ),

--- a/src/components/pages/index.js
+++ b/src/components/pages/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { CSSTransition } from 'react-transition-group';
+import Gridicon from 'gridicons';
 
 import PreferencesButton from '../preferences-button';
 
@@ -45,6 +46,15 @@ class Pages extends Component {
 											</svg>
 											<span>{ page.heading }</span>
 										</h1>
+										{ activePage !== 1 &&
+											<button
+												className="test-button"
+												onClick={ () => this.setActivePage( 1 ) }
+												title="Run unit tests."
+											>
+												<Gridicon icon="checkmark" />
+											</button>
+										}
 										<PreferencesButton
 											activePage={ activePage }
 											setActivePage={ this.setActivePage }

--- a/src/components/pages/style.css
+++ b/src/components/pages/style.css
@@ -27,3 +27,13 @@
 	transition: 300ms;
 	left: 350px;
 }
+
+.test-button {
+	border: none;
+	background: none;
+	cursor: pointer;
+}
+
+.test-button .gridicon {
+	fill: #82878C;
+}

--- a/src/components/test-panel/index.js
+++ b/src/components/test-panel/index.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react';
+import { normalize } from 'path';
+
+import './style.css';
+
+const { shell, remote } = window.require( 'electron' );
+
+class TestPanel extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.runCorePhpTests = this.runCorePhpTests.bind( this );
+	}
+
+	runCorePhpTests() {
+	}
+
+	render() {
+		return (
+			<div className="test">
+				<p>
+					<button onClick={ this.runCorePhpTests }>Run Core PHP Tests</button>
+				</p>
+			</div>
+		);
+	}
+}
+
+export default TestPanel;

--- a/src/components/test-panel/style.css
+++ b/src/components/test-panel/style.css
@@ -1,0 +1,5 @@
+.about > p {
+	margin: 20px 15px;
+	line-height: 1.3;
+	text-align: center;
+}


### PR DESCRIPTION
This should be able to run PHPUnit tests for Core and Gutenberg, as well as QUnit tests for Core and Jest tests for Gutenberg.

Fixes #29.