### PR TITLE
Allow Ctrl+C to work when running PHPUnit

### DIFF
--- a/src/services/docker/index.js
+++ b/src/services/docker/index.js
@@ -58,7 +58,7 @@ async function startDocker() {
 	}
 
 	const defaultOptions = {
-		version: '3',
+		version: '3.7',
 		services: {
 			'wordpress-develop': {
 				image: 'nginx:alpine',
@@ -111,6 +111,7 @@ async function startDocker() {
 					normalize( cwds[ 'wordpress-folder' ] ) + ':/wordpress-develop',
 					'phpunit-uploads:/wordpress-develop/src/wp-content/uploads',
 				],
+				init: true,
 			},
 		},
 		volumes: {


### PR DESCRIPTION
Adding the `init: true` setting changes the container startup, so that PHPUnit isn't run with PID 1. 

PID 1 doesn't respond to Ctrl+C.

Fixes #89.