### PR TITLE
Fix browserlist config

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,10 +112,5 @@
 			"pre-commit": "lint-staged"
 		}
 	},
-	"browserslist": [
-		">0.2%",
-		"not dead",
-		"not ie <= 11",
-		"not op_mini all"
-	]
+	"browserslist": "electron >= 4.0"
 }


### PR DESCRIPTION
Previously, we were experiencing an issue where a browserlist entry was automatically being added to the package.json on `npm run dev` (I think by `react-scripts`).

The automatically added entry was commited in #100. As pointed out in https://github.com/pento/testpress/pull/100#issuecomment-473513397, this looks wrong.

Browserlist supports electron versions since https://github.com/browserslist/browserslist/issues/96 was merged.

This PR updates the browserlist prop to the correct value for the testpress app. 