### PR TITLE
Fix external links

### DIFF
--- a/src/components/about-panel/index.js
+++ b/src/components/about-panel/index.js
@@ -12,6 +12,7 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import ExternalLink from '../external-link';
 import './style.scss';
 
 const { shell, remote } = window.require( 'electron' );
@@ -21,13 +22,7 @@ const logPath = normalize( remote.app.getPath( 'userData' ) + '/debug.log' );
 class AboutPanel extends Component {
 	render() {
 		const repositoryLink = (
-			<Button
-				isLink
-				className="about-panel__repository-link"
-				onClick={ () => shell.openExternal( 'https://github.com/pento/testpress' ) }
-			>
-				GitHub repository
-			</Button>
+			<ExternalLink href="https://github.com/pento/testpress">GitHub repository</ExternalLink>
 		);
 
 		return (

--- a/src/components/about-panel/style.scss
+++ b/src/components/about-panel/style.scss
@@ -4,16 +4,4 @@
 	padding: 0 15px 15px;
 	position: absolute;
 	text-align: center;
-
-	&__repository-link.is-link {
-		font-size: inherit;
-	}
-
-	.components-button.is-link {
-		color: $blue-medium-500;
-
-		.theme-dark & {
-			color: $blue-medium-200;
-		}
-	}
 }

--- a/src/components/external-link/index.js
+++ b/src/components/external-link/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * Electron dependencies
+ */
+const { shell } = window.require( 'electron' );
+
+export default function ExternalLink( { href, children } ) {
+	return (
+		// Disable reason: We can't use regular <a>s without an onClick handler in
+		// Electron because the href will open within the app shell.
+		// eslint-disable-next-line jsx-a11y/anchor-is-valid
+		<a
+			className="external-link"
+			role="link"
+			tabIndex="0"
+			onClick={ () => shell.openExternal( href ) }
+			onKeyPress={ ( { key } ) => {
+				if ( key === 'Enter' || key === ' ' ) {
+					shell.openExternal( href );
+				}
+			} }
+		>
+			{ children }
+		</a>
+	);
+}

--- a/src/components/external-link/style.scss
+++ b/src/components/external-link/style.scss
@@ -1,0 +1,6 @@
+@import "../../colors.scss";
+
+.external-link {
+	color: $blue-medium-500;
+	cursor: pointer;
+}

--- a/src/components/external-link/style.scss
+++ b/src/components/external-link/style.scss
@@ -3,4 +3,5 @@
 .external-link {
 	color: $blue-medium-500;
 	cursor: pointer;
+	text-decoration: underline;
 }

--- a/src/components/status-panel/missing-daemon-info.js
+++ b/src/components/status-panel/missing-daemon-info.js
@@ -9,6 +9,11 @@ import React, { useState } from 'react';
 import { Button } from '@wordpress/components';
 
 /**
+ * Internal dependencies
+ */
+import ExternalLink from '../external-link';
+
+/**
  * Electron dependencies
  */
 const { platform } = window.require( 'process' );
@@ -49,7 +54,7 @@ function OpenDockerButton() {
 }
 
 export default function MissingDaemonInfo() {
-	const link = <a href={ dockerDesktopURL }>{ dockerDesktopName }</a>;
+	const link = <ExternalLink href={ dockerDesktopURL }>{ dockerDesktopName }</ExternalLink>;
 
 	let button;
 

--- a/src/components/status-panel/missing-folder-info.js
+++ b/src/components/status-panel/missing-folder-info.js
@@ -9,6 +9,11 @@ import React from 'react';
 import { Button } from '@wordpress/components';
 
 /**
+ * Internal dependencies
+ */
+import ExternalLink from '../external-link';
+
+/**
  * Electron dependencies
  */
 const { remote, ipcRenderer } = window.require( 'electron' );
@@ -29,9 +34,13 @@ function selectWordPressFolder() {
 }
 
 export default function MissingFolderInfo() {
-	const desktopLink = <a href="https://desktop.github.com">GitHub Desktop</a>;
+	const desktopLink = (
+		<ExternalLink href="https://desktop.github.com">GitHub Desktop</ExternalLink>
+	);
 	const repositoryLink = (
-		<a href="https://github.com/WordPress/wordpress-develop">wordpress-develop</a>
+		<ExternalLink href="https://github.com/WordPress/wordpress-develop">
+			wordpress-develop
+		</ExternalLink>
 	);
 
 	return (
@@ -50,7 +59,9 @@ export default function MissingFolderInfo() {
 				clone { repositoryLink }.
 			</p>
 			<p>
-				<Button isLarge onClick={ selectWordPressFolder }>Choose WordPress Folder</Button>
+				<Button isLarge onClick={ selectWordPressFolder }>
+					Choose WordPress Folder
+				</Button>
 			</p>
 		</div>
 	);

--- a/src/components/status-panel/ready-info.js
+++ b/src/components/status-panel/ready-info.js
@@ -9,6 +9,11 @@ import React from 'react';
 import { Button } from '@wordpress/components';
 
 /**
+ * Internal dependencies
+ */
+import ExternalLink from '../external-link';
+
+/**
  * Electron dependencies
  */
 const { ipcRenderer, shell, remote } = window.require( 'electron' );
@@ -53,13 +58,7 @@ export default function ReadyInfo() {
 				something amazing!
 			</p>
 			<p>
-				<Button
-					isLink
-					className="status__site-link"
-					onClick={ () => shell.openExternal( siteURL ) }
-				>
-					{ siteURL }
-				</Button>
+				<ExternalLink href={ siteURL }>{ siteURL }</ExternalLink>
 				<br />
 				Username: admin
 				<br />

--- a/src/components/status-panel/style.scss
+++ b/src/components/status-panel/style.scss
@@ -9,10 +9,6 @@
 		margin: 0 5px;
 	}
 
-	&__site-link.is-link {
-		font-size: inherit;
-	}
-
 	&__message-container {
 		display: inline-block;
 		margin: 0;


### PR DESCRIPTION
Fixes #117.

Stops external links having a too-dark blue colour, and prevents them from opening within the Electron shell.

I introduced an `ExternalLink` component because some care is necessary when adding `onClick` to a `<a>` to make sure that it's all still accessible. 

<img width="367" alt="Screen Shot 2019-03-27 at 16 22 01" src="https://user-images.githubusercontent.com/612155/55052280-750e9e00-50ac-11e9-8dcf-4c127fd657d4.png">