### PR TITLE
Fix icon button colour

### DIFF
--- a/src/components/pages/style.scss
+++ b/src/components/pages/style.scss
@@ -63,9 +63,6 @@
 	}
 
 	.components-icon-button .dashicon {
-		.theme-light & {
-			fill: $blue-wordpress-700;
-		}
 		.theme-dark & {
 			fill: $blue-medium-100;
 		}
@@ -74,10 +71,6 @@
 	.components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
 	.components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):active,
 	.components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):focus {
-		.theme-light & {
-			color: $dark-gray-700;
-			background-color: $light-gray-200;
-		}
 		.theme-dark & {
 			color: $light-gray-200;
 			background-color: $dark-gray-700;


### PR DESCRIPTION
Fixes #116.

Makes the icon button grey again, and restores the native `IconButton` behaviour which is that the `fill` colour gets darker when you hover over the button. 

![button](https://user-images.githubusercontent.com/612155/55050338-3d9bf380-50a4-11e9-9e6f-d780cd68f0d2.gif)