### PR TITLE
Fix light theme colours

### DIFF
--- a/src/app/style.scss
+++ b/src/app/style.scss
@@ -19,7 +19,7 @@ body.trayright .tray-pointer {
 
 .testpress {
 	background-color: #fff;
-	color: $dark-gray-700;
+	color: $dark-gray-900;
 	height: 340px;
 
 	.theme-dark & {

--- a/src/app/style.scss
+++ b/src/app/style.scss
@@ -1,18 +1,16 @@
 @import "../_colors.scss";
 
 .tray-pointer {
-	height: 0;
-	width: 0;
+	border-bottom: 8px solid $light-gray-100;
 	border-left: 8px solid transparent;
 	border-right: 8px solid transparent;
+	height: 0;
+	margin: 0 auto;
+	width: 0;
 
-	.theme-light & {
-		border-bottom: 8px solid $light-gray-100;
-	}
 	.theme-dark & {
 		border-bottom: 8px solid $dark-gray-400;
 	}
-	margin: 0 auto;
 }
 
 body.trayright .tray-pointer {
@@ -21,14 +19,11 @@ body.trayright .tray-pointer {
 
 .testpress {
 	background-color: #fff;
-	color: #191e23;
+	color: $dark-gray-700;
 	height: 340px;
-	.theme-light & {
-		color: $dark-gray-700;
-		background-color: $light-gray-100;
-	}
+
 	.theme-dark & {
-		color: $light-gray-200;
 		background-color: $dark-gray-400;
+		color: $light-gray-200;
 	}
 }

--- a/src/app/style.scss
+++ b/src/app/style.scss
@@ -9,7 +9,7 @@
 	width: 0;
 
 	.theme-dark & {
-		border-bottom: 8px solid $dark-gray-400;
+		border-bottom-color: $dark-gray-400;
 	}
 }
 

--- a/src/components/about-panel/style.scss
+++ b/src/components/about-panel/style.scss
@@ -10,9 +10,8 @@
 	}
 
 	.components-button.is-link {
-		.theme-light & {
-			color: $blue-medium-500;
-		}
+		color: $blue-medium-500;
+
 		.theme-dark & {
 			color: $blue-medium-200;
 		}

--- a/src/components/about-panel/style.scss
+++ b/src/components/about-panel/style.scss
@@ -6,7 +6,7 @@
 	text-align: center;
 
 	&__repository-link.is-link {
-		font-size: 16px;
+		font-size: inherit;
 	}
 
 	.components-button.is-link {

--- a/src/components/pages/style.scss
+++ b/src/components/pages/style.scss
@@ -44,7 +44,7 @@
 		padding: 10px;
 
 		.theme-dark & {
-			border-bottom: 1px solid $light-gray-100;
+			border-bottom-color: $light-gray-100;
 			color: $light-gray-200;
 		}
 	}

--- a/src/components/pages/style.scss
+++ b/src/components/pages/style.scss
@@ -35,8 +35,8 @@
 
 	&__page-header {
 		align-items: center;
-		border-bottom: 1px solid $dark-gray-400;
-		color: $dark-gray-700;
+		border-bottom: 1px solid $light-gray-500;
+		color: $dark-gray-500;
 		display: flex;
 		height: 35px;
 		padding: 10px;
@@ -57,24 +57,14 @@
 		}
 	}
 
-	.components-icon-button .dashicon {
-		fill: $blue-wordpress-700;
-
-		.theme-dark & {
-			fill: $blue-medium-100;
-		}
+	.theme-dark & .components-icon-button .dashicon {
+		fill: $blue-medium-100;
 	}
 
-	.components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
-	.components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):active,
-	.components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):focus {
-		background-color: $light-gray-200;
-		color: $dark-gray-700;
-
-		.theme-dark & {
-			background-color: $dark-gray-700;
-			color: $light-gray-200;
-		}
+	.theme-dark & .components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
+	.theme-dark & .components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):active,
+	.theme-dark & .components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):focus {
+		background-color: $dark-gray-700;
 	}
 
 	.components-button.is-link {

--- a/src/components/pages/style.scss
+++ b/src/components/pages/style.scss
@@ -7,7 +7,6 @@
 
 	&__page {
 		background-color: $light-gray-100;
-		color: $dark-gray-700;
 		height: 100%;
 		left: 350px;
 		position: absolute;
@@ -15,7 +14,6 @@
 
 		.theme-dark & {
 			background-color: $dark-gray-400;
-			color: $light-gray-200;
 		}
 	}
 

--- a/src/components/pages/style.scss
+++ b/src/components/pages/style.scss
@@ -6,17 +6,16 @@
 	overflow: hidden;
 
 	&__page {
+		background-color: $light-gray-100;
+		color: $dark-gray-700;
 		height: 100%;
-		position: absolute;
 		left: 350px;
+		position: absolute;
 		width: 350px;
-		.theme-light & {
-			color: $dark-gray-700;
-			background-color: $light-gray-100;
-		}
+
 		.theme-dark & {
-			color: $light-gray-200;
 			background-color: $dark-gray-400;
+			color: $light-gray-200;
 		}
 	}
 
@@ -37,35 +36,32 @@
 	}
 
 	&__page-header {
+		align-items: center;
+		border-bottom: 1px solid $dark-gray-400;
+		color: $dark-gray-700;
+		display: flex;
 		height: 35px;
 		padding: 10px;
-		display: flex;
-		align-items: center;
-		.theme-light & {
-			color: $dark-gray-700;
-			border-bottom: 1px solid $dark-gray-400;
-		}
+
 		.theme-dark & {
-			color: $light-gray-200;
 			border-bottom: 1px solid $light-gray-100;
+			color: $light-gray-200;
 		}
 	}
 
 	&__page-title-logo {
-		margin: 5px;
+		fill: $blue-wordpress-700;
 		height: 25px;
-		.theme-light & {
-			fill: $blue-wordpress-700;
-		}
+		margin: 5px;
+
 		.theme-dark & {
 			fill: $blue-medium-100;
 		}
 	}
 
 	.components-icon-button .dashicon {
-		.theme-light & {
-			fill: $blue-wordpress-700;
-		}
+		fill: $blue-wordpress-700;
+
 		.theme-dark & {
 			fill: $blue-medium-100;
 		}
@@ -74,20 +70,18 @@
 	.components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
 	.components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):active,
 	.components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):focus {
-		.theme-light & {
-			color: $dark-gray-700;
-			background-color: $light-gray-200;
-		}
+		background-color: $light-gray-200;
+		color: $dark-gray-700;
+
 		.theme-dark & {
-			color: $light-gray-200;
 			background-color: $dark-gray-700;
+			color: $light-gray-200;
 		}
 	}
 
 	.components-button.is-link {
-		.theme-light & {
-			color: $blue-medium-500;
-		}
+		color: $blue-medium-500;
+
 		.theme-dark & {
 			color: $blue-medium-200;
 		}

--- a/src/components/preferences-panel/style.scss
+++ b/src/components/preferences-panel/style.scss
@@ -43,7 +43,7 @@
 		.theme-dark & {
 			color: $light-gray-200;
 			background-color: $dark-gray-400;
-			border: 1px solid $light-gray-200;
+			border-color: $light-gray-200;
 		}
 	}
 

--- a/src/components/preferences-panel/style.scss
+++ b/src/components/preferences-panel/style.scss
@@ -5,26 +5,24 @@
 	&__input > label {
 		display: block;
 		margin: 10px 0;
-		.theme-light & {
-			color: $dark-gray-700;
-		}
+		color: $dark-gray-700;
+
 		.theme-dark & {
 			color: $light-gray-200;
 		}
 	}
 
 	&__directory-select > button {
-		border: none;
-		text-decoration: underline;
-		cursor: pointer;
 		background: none;
+		border: none;
+		color: $dark-gray-700;
+		cursor: pointer;
 		display: block;
 		font-size: inherit;
 		margin: 10px 0;
 		padding: 0;
-		.theme-light & {
-			color: $dark-gray-700;
-		}
+		text-decoration: underline;
+
 		.theme-dark & {
 			color: $light-gray-200;
 		}
@@ -36,13 +34,12 @@
 	}
 
 	&__input > input {
-		padding: 5px 10px;
+		background-color: $light-gray-100;
 		border-radius: 3px;
-		.theme-light & {
-			color: $dark-gray-700;
-			background-color: $light-gray-100;
-			border: 1px solid $light-gray-100;
-		}
+		border: 1px solid $light-gray-100;
+		color: $dark-gray-700;
+		padding: 5px 10px;
+
 		.theme-dark & {
 			color: $light-gray-200;
 			background-color: $dark-gray-400;

--- a/src/components/status-panel/style.scss
+++ b/src/components/status-panel/style.scss
@@ -26,10 +26,10 @@
 		.components-spinner {
 			transform: scale(0.8);
 			background-color: currentColor;
+
 			&::before {
-				.theme-light & {
-					background-color: #fff;
-				}
+				background-color: #fff;
+
 				.theme-dark & {
 					background-color: #000;
 				}

--- a/src/components/status-panel/style.scss
+++ b/src/components/status-panel/style.scss
@@ -10,7 +10,7 @@
 	}
 
 	&__site-link.is-link {
-		font-size: 16px;
+		font-size: inherit;
 	}
 
 	&__message-container {

--- a/src/components/tabs/style.scss
+++ b/src/components/tabs/style.scss
@@ -2,11 +2,10 @@
 
 .tabs {
 	&__headings {
-		padding: 20px 15px 10px;
 		border-bottom: 1px solid #ccc;
-		.theme-light & {
-			color: $dark-gray-700;
-		}
+		color: $dark-gray-700;
+		padding: 20px 15px 10px;
+
 		.theme-dark & {
 			color: $light-gray-200;
 		}
@@ -19,10 +18,9 @@
 	}
 
 	&__heading--active {
-		.theme-light & {
-			color: $blue-wordpress-700;
-			border-bottom: 1px solid $light-gray-100;
-		}
+		color: $blue-wordpress-700;
+		border-bottom: 1px solid $light-gray-100;
+
 		.theme-dark & {
 			color: $blue-medium-200;
 			border-bottom: 1px solid $dark-gray-400;
@@ -30,10 +28,9 @@
 	}
 
 	&__pages {
+		color: $dark-gray-700;
 		padding: 20px 15px;
-		.theme-light & {
-			color: $dark-gray-700;
-		}
+
 		.theme-dark & {
 			color: $light-gray-200;
 		}

--- a/src/components/tabs/style.scss
+++ b/src/components/tabs/style.scss
@@ -23,7 +23,7 @@
 
 		.theme-dark & {
 			color: $blue-medium-200;
-			border-bottom: 1px solid $dark-gray-400;
+			border-bottom-color: $dark-gray-400;
 		}
 	}
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,8 +1,10 @@
 @import "../node_modules/@wordpress/components/build-style/style.css";
 @import "./_colors.scss";
+
 body {
+	font-family: sans-serif;
+	font-size: 16px;
+	line-height: 1.35;
 	margin: 0;
 	padding: 0;
-	font-family: sans-serif;
-	line-height: 1.35;
 }


### PR DESCRIPTION
Simplifies the CSS somewhat by removing some redundant CSS rules, and tweaks the light theme so that:

- The icon in the upper right is grey, matches Gutenberg, and darkens on hover. Fixes #116
- The border underneath the header is a lighter grey that matches Gutenberg. Fixes #123
- The header text is a lighter grey that matches Gutenberg
- The body text is a darker grey that matches Gutenberg

I haven't touched dark mode which is tougher to tweak since there's no dark Gutenberg to copy 🙂

<img width="362" alt="Screen Shot 2019-03-27 at 16 12 31" src="https://user-images.githubusercontent.com/612155/55051886-244a7580-50ab-11e9-9203-2942ca37b7d9.png">