### PR TITLE
Disable 'Open Docker' button after you click it

### DIFF
--- a/src/components/status-panel/missing-daemon-info.js
+++ b/src/components/status-panel/missing-daemon-info.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 
 /**
  * WordPress dependencies
@@ -31,17 +31,30 @@ if ( platform === 'win32' ) {
 	// TODO: Set dockerDesktopPath to something reasonable for Windows.
 }
 
+function OpenDockerButton() {
+	const [ isOpening, setIsOpening ] = useState( false );
+
+	return (
+		<Button
+			isLarge
+			disabled={ isOpening }
+			onClick={ () => {
+				shell.openItem( dockerDesktopPath );
+				setIsOpening( true );
+			} }
+		>
+			{ isOpening ? `Opening ${ dockerDesktopName }…` : `Open ${ dockerDesktopName }` }
+		</Button>
+	);
+}
+
 export default function MissingDaemonInfo() {
 	const link = <a href={ dockerDesktopURL }>{ dockerDesktopName }</a>;
 
 	let button;
 
 	if ( dockerDesktopPath && existsSync( dockerDesktopPath ) ) {
-		button = (
-			<Button isLarge onClick={ () => shell.openItem( dockerDesktopPath ) }>
-				Open { dockerDesktopName }
-			</Button>
-		);
+		button = <OpenDockerButton />;
 	} else {
 		button = (
 			<Button isLarge onClick={ () => shell.openExternal( dockerDesktopURL ) }>


### PR DESCRIPTION
Fixes #115.

I'm keeping it simple for now and just disabling the _Open Docker_ button and changing the label to _Opening Docker…_ when it's clicked.