### PR TITLE
Copy PHP config files to the tools directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,9 @@
 		"appId": "org.wordpress.testpress",
 		"productName": "TestPress",
 		"asarUnpack": [
-			"src/services/docker/default.conf"
+			"src/services/docker/default.conf",
+			"src/services/docker/php-config.ini",
+			"src/services/docker/phpunit-config.ini"
 		],
 		"extends": null,
 		"files": [

--- a/src/services/docker/index.js
+++ b/src/services/docker/index.js
@@ -159,6 +159,8 @@ async function startDocker() {
 	writeFileSync( normalize( TOOLS_DIR + '/docker-compose.scripts.yml' ), scriptOptionsYaml );
 
 	copyFileSync( normalize( __dirname + '/default.conf' ), normalize( TOOLS_DIR + '/default.conf' ) );
+	copyFileSync( normalize( __dirname + '/php-config.ini' ), normalize( TOOLS_DIR + '/php-config.ini' ) );
+	copyFileSync( normalize( __dirname + '/phpunit-config.ini' ), normalize( TOOLS_DIR + '/phpunit-config.ini' ) );
 
 	if ( USING_TOOLBOX ) {
 		await startDockerMachine();


### PR DESCRIPTION
Fixes #101.

Ensures that the PHP config files are available to be used by the Docker containers, including when TestPress is distributed as a bundle.

## Testing

```
cd ~/Library/Application Support/testpress/tools
rm php-config.ini phpunit-config.ini
```

Then start TestPress, and ensure the files are copied correctly.