### PR TITLE
Fix nginx's redirect config.

### DIFF
--- a/src/services/docker/default.conf
+++ b/src/services/docker/default.conf
@@ -4,6 +4,8 @@ server {
 	listen 80 default_server;
 	listen [::]:80 default_server;
 
+	absolute_redirect off;
+
 	server_name localhost;
 
 	client_max_body_size 1g;


### PR DESCRIPTION
Fixes https://github.com/pento/testpress/issues/106.

Turning off the `absolute_redirect` [directive](https://nginx.org/en/docs/http/ngx_http_core_module.html#absolute_redirect) changes redirects to be relative, so the port won't be removed from the URL.

This method also allows the port that Docker is listening on to be changed without needing to alter the nginx config.