### PR TITLE
Ensure the Docker containers are shutdown on exit.

### DIFF
--- a/src/services/docker/index.js
+++ b/src/services/docker/index.js
@@ -497,11 +497,13 @@ function shutdown() {
 		'down',
 	], {
 		cwd: TOOLS_DIR,
+		detached: true,
 		encoding: 'utf8',
 		env: {
 			PATH: process.env.PATH,
 			...dockerEnv,
 		},
+		stdio: [ 'ignore', 'ignore', 'ignore' ],
 	} );
 }
 


### PR DESCRIPTION
TestPress will spawn a process running `docker-compose down` on exit, but there's a race condition between that process triggering the containers to shutdown, and Node killing off its child processes.

By defining this process as being detached (and not attaching to any IO streams), it will survive Node quitting, so that the containers will actually be shutdown.

## Testing

- Start TestPress
- At any point, press Cmd+Q to quit.
- Run:

```
> cd ~/Library/Application Support/testpress/tools
> docker-compose ps
```

Prior to this PR, the containers would often still be running. After this PR, not so much.