### PR TITLE
Add bottom tray support

### DIFF
--- a/src/app/style.scss
+++ b/src/app/style.scss
@@ -13,6 +13,18 @@
 	}
 }
 
+.traybottomcenter,
+.traybottomright {
+	.tray-pointer {
+		position: absolute;
+		bottom: 2px;
+		left: 0;
+		right: 0;
+		border-bottom: unset;
+		border-top: 8px solid $light-gray-100;
+	}
+}
+
 body.trayright .tray-pointer {
 	margin-right: 10px;
 }

--- a/src/electron-runner.js
+++ b/src/electron-runner.js
@@ -145,8 +145,13 @@ const showWindow = () => {
 		position = 'trayRight';
 	}
 
+	// If the tray isn't at the top, assume it's at the bottom.
+	if ( trayBounds.y > 500 ) {
+		position = position.replace( 'tray', 'trayBottom' );
+	}
+
 	const addClassScript = `
-	document.body.classList.remove( 'traycenter', 'trayright' );
+	document.body.classList.remove( 'traycenter', 'trayright', 'traybottomcenter', 'traybottomright' );
 	document.body.classList.add( '${ position.toLowerCase() }' );
 	`;
 


### PR DESCRIPTION
Windows usually has the tray at the bottom of the screen, so we need to adjust the window position and tray pointer to match.

![Screenshot of the TestPress window appearing at the bottom of the screen](https://user-images.githubusercontent.com/352291/55306346-a4078400-549f-11e9-9ef4-eaf7506bfcfa.PNG)
