### PR TITLE
Update preference screen components

### DIFF
--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -1,0 +1,182 @@
+@import "./variables.scss";
+
+// Tabs, Inputs, Square buttons.
+@mixin input-style__neutral() {
+	box-shadow: 0 0 0 transparent;
+	transition: box-shadow 0.1s linear;
+	border-radius: $radius-round-rectangle;
+	border: $border-width solid $dark-gray-150;
+}
+
+@mixin input-style__focus() {
+	color: $dark-gray-900;
+	border-color: $blue-medium-500;
+	box-shadow: 0 0 0 1px $blue-medium-500;
+
+	// Windows High Contrast mode will show this outline, but not the box-shadow.
+	outline: 2px solid transparent;
+	outline-offset: -2px;
+}
+
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+@mixin reset {
+	box-sizing: border-box;
+
+	*,
+	*::before,
+	*::after {
+		box-sizing: inherit;
+	}
+
+	select {
+		font-size: $default-font-size;
+		color: $dark-gray-500;
+	}
+
+	.input-control, // Upstream name is `.regular-text`.
+	input[type="text"],
+	input[type="search"],
+	input[type="radio"],
+	input[type="tel"],
+	input[type="time"],
+	input[type="url"],
+	input[type="week"],
+	input[type="password"],
+	input[type="checkbox"],
+	input[type="color"],
+	input[type="date"],
+	input[type="datetime"],
+	input[type="datetime-local"],
+	input[type="email"],
+	input[type="month"],
+	input[type="number"],
+	select,
+	textarea {
+		font-family: $default-font;
+		padding: 6px 8px;
+		@include input-style__neutral();
+
+		font-size: $default-font-size;
+
+		&:focus {
+			@include input-style__focus();
+		}
+	}
+
+	input[type="number"] {
+		padding-left: 4px;
+		padding-right: 4px;
+	}
+
+	select {
+		padding: 2px;
+
+		&:focus {
+			border-color: $blue-medium-600;
+			// Windows High Contrast mode will show this outline
+			outline: 2px solid transparent;
+			outline-offset: 0;
+		}
+	}
+
+	input[type="checkbox"],
+	input[type="radio"] {
+		border: $border-width + 1 solid $dark-gray-300;
+		margin-right: 12px;
+		transition: none;
+
+		&:focus {
+			border-color: $dark-gray-300;
+			box-shadow: 0 0 0 1px $dark-gray-300;
+		}
+
+		&:checked {
+			background: theme(toggle);
+			border-color: theme(toggle);
+		}
+
+		&:checked:focus {
+			box-shadow: 0 0 0 2px $dark-gray-500;
+		}
+	}
+
+	input[type="checkbox"] {
+		border-radius: $radius-round-rectangle / 2;
+
+		&:checked::before,
+		&[aria-checked="mixed"]::before {
+			margin: -3px -5px;
+			color: $white;
+		}
+
+		&[aria-checked="mixed"] {
+			background: theme(toggle);
+			border-color: theme(toggle);
+
+			&::before {
+				// Inherited from `forms.css`.
+				// See: https://github.com/WordPress/wordpress-develop/tree/5.1.1/src/wp-admin/css/forms.css#L122-L132
+				content: "\f460";
+				float: left;
+				display: inline-block;
+				vertical-align: middle;
+				width: 16px;
+				/* stylelint-disable */
+				font: normal 30px/1 dashicons;
+				/* stylelint-enable */
+				speak: none;
+				-webkit-font-smoothing: antialiased;
+				-moz-osx-font-smoothing: grayscale;
+			}
+
+			&:focus {
+				box-shadow: 0 0 0 2px $dark-gray-500;
+			}
+		}
+	}
+
+	input[type="radio"] {
+		border-radius: $radius-round;
+
+		&:checked::before {
+			margin: 6px 0 0 6px;
+			background-color: $white;
+		}
+	}
+
+	// Placeholder colors
+	input,
+	textarea {
+		// Use opacity to work in various editor styles.
+		&::-webkit-input-placeholder {
+			color: $dark-opacity-300;
+		}
+
+		&::-moz-placeholder {
+			opacity: 1; // Necessary because Firefox reduces this from 1.
+			color: $dark-opacity-300;
+		}
+
+		&:-ms-input-placeholder {
+			color: $dark-opacity-300;
+		}
+
+		.is-dark-theme & {
+			&::-webkit-input-placeholder {
+				color: $light-opacity-300;
+			}
+
+			&::-moz-placeholder {
+				opacity: 1; // Necessary because Firefox reduces this from 1.
+				color: $light-opacity-300;
+			}
+
+			&:-ms-input-placeholder {
+				color: $light-opacity-300;
+			}
+		}
+	}
+}

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -6,11 +6,6 @@
 $default-font: -apple-system, BlinkMacSystemFont,"Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,"Helvetica Neue", sans-serif;
 $default-font-size: 13px;
 $default-line-height: 1.4;
-// $editor-font: "Noto Serif", serif;
-// $editor-html-font: Menlo, Consolas, monaco, monospace;
-// $editor-font-size: 16px;
-// $text-editor-font-size: 14px;
-// $editor-line-height: 1.8;
 $big-font-size: 18px;
 $mobile-text-min-font-size: 16px; // Any font size below 16px will cause Mobile Safari to "zoom in"
 

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,0 +1,26 @@
+/**
+ * Often re-used variables
+ */
+
+// Fonts & basics
+$default-font: -apple-system, BlinkMacSystemFont,"Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,"Helvetica Neue", sans-serif;
+$default-font-size: 13px;
+$default-line-height: 1.4;
+// $editor-font: "Noto Serif", serif;
+// $editor-html-font: Menlo, Consolas, monaco, monospace;
+// $editor-font-size: 16px;
+// $text-editor-font-size: 14px;
+// $editor-line-height: 1.8;
+$big-font-size: 18px;
+$mobile-text-min-font-size: 16px; // Any font size below 16px will cause Mobile Safari to "zoom in"
+
+// Grid size
+$grid-size-small: 4px;
+$grid-size: 8px;
+$grid-size-large: 16px;
+
+// Buttons & UI Widgets
+$radius-round-rectangle: 4px;
+$radius-round: 50%;
+
+$border-width: 1px;

--- a/src/components/pages/style.scss
+++ b/src/components/pages/style.scss
@@ -38,7 +38,7 @@
 		border-bottom: 1px solid $light-gray-500;
 		color: $dark-gray-500;
 		display: flex;
-		height: 35px;
+		height: 45px;
 		padding: 10px;
 
 		.theme-dark & {

--- a/src/components/pages/style.scss
+++ b/src/components/pages/style.scss
@@ -38,7 +38,7 @@
 		border-bottom: 1px solid $light-gray-500;
 		color: $dark-gray-500;
 		display: flex;
-		height: 45px;
+		height: 55px;
 		padding: 10px;
 
 		.theme-dark & {

--- a/src/components/preferences-panel/basic-preferences.js
+++ b/src/components/preferences-panel/basic-preferences.js
@@ -3,30 +3,47 @@
  */
 import React from 'react';
 
+/**
+ * WordPress dependencies
+ */
+import { BaseControl, Button } from '@wordpress/components';
+
+function DirectorySelect( { id, label, onClick, path } ) {
+	return (
+		<BaseControl
+			id={ id }
+			className="preferences-panel__directory-select"
+			label={ label }
+		>
+			<div className="preferences-panel__directory-select-path">
+				{ path ? path : 'No folder selected' }
+			</div>
+			<Button
+				id={ id }
+				onClick={ onClick }
+				isLink
+			>
+				Choose a folder
+			</Button>
+		</BaseControl>
+	);
+}
+
 export default function BasicPreferences( { directory, showDirectorySelect } ) {
 	return (
 		<div className="preferences-panel">
-			<div className="preferences-panel__directory-select">
-				<label htmlFor="preferences-wordpress-folder">WordPress Folder:</label>
-				{ directory.wordpress ? directory.wordpress : 'No folder selected' }
-				<button
-					id="preferences-wordpress-folder"
-					onClick={ () => showDirectorySelect( 'WordPress' ) }
-				>
-					{ 'Choose a folder' }
-				</button>
-			</div>
-			<div className="preferences-panel__directory-select">
-				<label htmlFor="preferences-gutenberg-folder">Gutenberg Folder:</label>
-				{ directory.gutenberg ? directory.gutenberg : 'No folder selected' }
-				<button
-					id="preferences-gutenberg-folder"
-					onClick={ () => showDirectorySelect( 'Gutenberg' ) }
-				>
-					{ 'Choose a folder' }
-				</button>
-
-			</div>
+			<DirectorySelect
+				id="preferences-wordpress-folder"
+				label="WordPress Folder"
+				onClick={ () => showDirectorySelect( 'WordPress' ) }
+				path={ directory.wordpress }
+			/>
+			<DirectorySelect
+				id="preferences-gutenberg-folder"
+				label="Gutenberg Folder"
+				onClick={ () => showDirectorySelect( 'Gutenberg' ) }
+				path={ directory.gutenberg }
+			/>
 		</div>
 	);
 }

--- a/src/components/preferences-panel/site-preferences.js
+++ b/src/components/preferences-panel/site-preferences.js
@@ -24,10 +24,6 @@ export default function SitePreferences( { port, onPortChange, onPortInputBlur }
 					onBlur={ onPortInputBlur }
 				/>
 			</BaseControl>
-			{ /* <div className="preferences-panel__input preferences-panel__input--short preferences-panel__input--inline">
-				<label htmlFor="preferences-port">Port Number:</label>
-
-			</div> */ }
 		</div>
 	);
 }

--- a/src/components/preferences-panel/site-preferences.js
+++ b/src/components/preferences-panel/site-preferences.js
@@ -3,11 +3,19 @@
  */
 import React from 'react';
 
+/**
+ * WordPress dependencies
+ */
+import { BaseControl } from '@wordpress/components';
+
 export default function SitePreferences( { port, onPortChange, onPortInputBlur } ) {
 	return (
 		<div className="preferences-panel">
-			<div className="preferences-panel__input preferences-panel__input--short preferences-panel__input--inline">
-				<label htmlFor="preferences-port">Port Number:</label>
+			<BaseControl
+				id="preferences-port"
+				className="preferences-panel__input"
+				label="Port Number"
+			>
 				<input
 					type="number"
 					id="preferences-port"
@@ -15,8 +23,11 @@ export default function SitePreferences( { port, onPortChange, onPortInputBlur }
 					onChange={ ( event ) => onPortChange( event.target.value ) }
 					onBlur={ onPortInputBlur }
 				/>
+			</BaseControl>
+			{ /* <div className="preferences-panel__input preferences-panel__input--short preferences-panel__input--inline">
+				<label htmlFor="preferences-port">Port Number:</label>
 
-			</div>
+			</div> */ }
 		</div>
 	);
 }

--- a/src/components/preferences-panel/style.scss
+++ b/src/components/preferences-panel/style.scss
@@ -19,39 +19,10 @@
 		}
 	}
 
-	&__input label {
-		display: block;
-		margin: 10px 0;
-		color: $dark-gray-700;
-	}
-
 	&__directory-select label,
 	&__input label {
 		.theme-dark & {
 			color: $light-gray-200;
 		}
-	}
-
-	&__input--inline > label {
-		display: inline-block;
-		margin-right: 10px;
-	}
-
-	&__input > input {
-		background-color: $light-gray-100;
-		border-radius: 3px;
-		border: 1px solid $light-gray-100;
-		color: $dark-gray-700;
-		padding: 5px 10px;
-
-		.theme-dark & {
-			color: $light-gray-200;
-			background-color: $dark-gray-400;
-			border-color: $light-gray-200;
-		}
-	}
-
-	&__input--short > input {
-		width: 50px;
 	}
 }

--- a/src/components/preferences-panel/style.scss
+++ b/src/components/preferences-panel/style.scss
@@ -1,28 +1,32 @@
 @import "../../_colors.scss";
 
 .preferences-panel {
-	&__directory-select > label,
-	&__input > label {
-		display: block;
-		margin: 10px 0;
-		color: $dark-gray-700;
+	&__directory-select {
+		margin-bottom: 1rem;
+	}
 
+	&__directory-select-path {
+		margin-bottom: 4px;
+	}
+
+	&__directory-select .components-button {
 		.theme-dark & {
 			color: $light-gray-200;
+
+			&:focus {
+				background: transparent;
+			}
 		}
 	}
 
-	&__directory-select > button {
-		background: none;
-		border: none;
-		color: $dark-gray-700;
-		cursor: pointer;
+	&__input label {
 		display: block;
-		font-size: inherit;
 		margin: 10px 0;
-		padding: 0;
-		text-decoration: underline;
+		color: $dark-gray-700;
+	}
 
+	&__directory-select label,
+	&__input label {
 		.theme-dark & {
 			color: $light-gray-200;
 		}

--- a/src/components/tabs/index.js
+++ b/src/components/tabs/index.js
@@ -22,20 +22,21 @@ class Tabs extends Component {
 
 		return (
 			<div className="tabs">
-				<div className="tabs__headings">
+				<ul className="tabs__headings">
 					{ Object.keys( tabs ).map( ( label ) => {
 						const statusClassName = label === activeTab ? 'tabs__heading--active' : 'tabs__heading--inactive';
 						return (
-							<button
-								key={ label + '-tab' }
-								className={ `tabs__heading ${ statusClassName }` }
-								onClick={ () => this.setState( { activeTab: label } ) }
-							>
-								{ label }
-							</button>
+							<li key={ label + '-tab' }>
+								<button
+									className={ `tabs__heading ${ statusClassName }` }
+									onClick={ () => this.setState( { activeTab: label } ) }
+								>
+									{ label }
+								</button>
+							</li>
 						);
 					} ) }
-				</div>
+				</ul>
 				<div className="tabs__pages">
 					{ Object.keys( tabs ).map( ( label ) => {
 						const statusClassName = label === activeTab ? 'tabs__page--active' : 'tabs__page--inactive';

--- a/src/components/tabs/index.js
+++ b/src/components/tabs/index.js
@@ -26,13 +26,13 @@ class Tabs extends Component {
 					{ Object.keys( tabs ).map( ( label ) => {
 						const statusClassName = label === activeTab ? 'tabs__heading--active' : 'tabs__heading--inactive';
 						return (
-							<span
+							<button
+								key={ label + '-tab' }
 								className={ `tabs__heading ${ statusClassName }` }
 								onClick={ () => this.setState( { activeTab: label } ) }
-								key={ label + '-tab' }
 							>
 								{ label }
-							</span>
+							</button>
 						);
 					} ) }
 				</div>

--- a/src/components/tabs/style.scss
+++ b/src/components/tabs/style.scss
@@ -2,6 +2,10 @@
 
 .tabs {
 	&__headings {
+		display: flex;
+		padding: 0;
+		margin: 0;
+		list-style: none;
 		height: 3rem;
 		border-bottom: 1px solid #ccc;
 		color: $dark-gray-700;

--- a/src/components/tabs/style.scss
+++ b/src/components/tabs/style.scss
@@ -2,9 +2,9 @@
 
 .tabs {
 	&__headings {
+		height: 3rem;
 		border-bottom: 1px solid #ccc;
 		color: $dark-gray-700;
-		padding: 20px 15px 10px;
 
 		.theme-dark & {
 			color: $light-gray-200;
@@ -12,24 +12,41 @@
 	}
 
 	&__heading {
-		margin-right: 20px;
-		padding-bottom: 10px;
+		height: 100%;
+		padding: 0 1rem;
+		font-size: 1rem;
 		cursor: pointer;
+		border: none;
+		background: none;
+
+		&:focus {
+			outline-offset: -1px;
+			outline: 1px dotted $dark-gray-500;
+		}
+
+		.theme-dark & {
+			color: $light-gray-200;
+
+			&:focus {
+				outline-color: $light-gray-500;
+			}
+		}
 	}
 
 	&__heading--active {
 		color: $blue-wordpress-700;
-		border-bottom: 1px solid $light-gray-100;
+		box-shadow: inset 0 -3px $blue-wordpress-700;
 
 		.theme-dark & {
 			color: $blue-medium-200;
-			border-bottom-color: $dark-gray-400;
+			box-shadow: inset 0 -3px $blue-medium-200;
 		}
+
 	}
 
 	&__pages {
 		color: $dark-gray-700;
-		padding: 20px 15px;
+		padding: 1rem;
 
 		.theme-dark & {
 			color: $light-gray-200;

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,6 @@
 @import "../node_modules/@wordpress/components/build-style/style.css";
 @import "./_colors.scss";
+@import "./_mixins.scss";
 
 body {
 	font-family: sans-serif;
@@ -7,4 +8,7 @@ body {
 	line-height: 1.35;
 	margin: 0;
 	padding: 0;
+
+	@include reset;
 }
+


### PR DESCRIPTION
Closes #119

## Description
Switches to using `@wordpress/components` in the preferences panel.

This ended up being slightly more involved than I'd planned, but that was partly out of necessity. This PR:
- Duplicates some mixins from Gutenberg that are responsible for bringing across default input styles (reset, input-style__neutral, input-style__focused).
- Duplicates some variable from Gutenberg (again, only those that seem like they'd be useful or where needed.)
- Reworks the preference panel tab headers to ensure they can be tabbed. There was no component to use here from `@wordpress/components`, but I've used the same markup and styles as Gutenberg uses for its sidebar tabs.
- Use `BaseControl` and `Button`s for the directory selection UI in the basic preferences.
- Use `BaseControl` for the port UI in the site preferences.

## How has this been tested?
Tested both light and dark mode.

## Screenshots <!-- if applicable -->
**Basic Preferences**

*before*
<img width="360" alt="Screen Shot 2019-04-02 at 4 46 42 pm" src="https://user-images.githubusercontent.com/677833/55390026-f06ac680-5568-11e9-9199-940619ac1be9.png">

*after*
<img width="362" alt="Screen Shot 2019-04-02 at 5 39 52 pm" src="https://user-images.githubusercontent.com/677833/55392754-82290280-556e-11e9-9a2f-db4b2e6bb0b6.png">

**Site Preferences**

*before*
<img width="363" alt="Screen Shot 2019-04-02 at 4 46 53 pm" src="https://user-images.githubusercontent.com/677833/55390124-21e39200-5569-11e9-8144-1ea1a9f5691a.png">

*after*
<img width="356" alt="Screen Shot 2019-04-02 at 5 40 02 pm" src="https://user-images.githubusercontent.com/677833/55392784-8d7c2e00-556e-11e9-8cfb-8e051607974a.png">

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate.