### PR TITLE
Upgrade @wordpress/scripts to 3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -592,6 +592,15 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+			"integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-transform-modules-amd": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
@@ -672,6 +681,15 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+			"integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-transform-react-constant-elements": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.2.0.tgz",
@@ -729,6 +747,15 @@
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.13.3"
+			}
+		},
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+			"integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
@@ -947,13 +974,12 @@
 			"dev": true
 		},
 		"@jest/console": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.3.0.tgz",
-			"integrity": "sha512-NaCty/OOei6rSDcbPdMiCbYCI0KGFGPgGO6B09lwWt5QTxnkuhKYET9El5u5z1GAcSxkQmSMtM63e24YabCWqA==",
+			"version": "24.7.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
+			"integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
 			"dev": true,
 			"requires": {
 				"@jest/source-map": "^24.3.0",
-				"@types/node": "*",
 				"chalk": "^2.0.1",
 				"slash": "^2.0.0"
 			},
@@ -967,32 +993,32 @@
 			}
 		},
 		"@jest/core": {
-			"version": "24.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.5.0.tgz",
-			"integrity": "sha512-RDZArRzAs51YS7dXG1pbXbWGxK53rvUu8mCDYsgqqqQ6uSOaTjcVyBl2Jce0exT2rSLk38ca7az7t2f3b0/oYQ==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.8.0.tgz",
+			"integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.3.0",
-				"@jest/reporters": "^24.5.0",
-				"@jest/test-result": "^24.5.0",
-				"@jest/transform": "^24.5.0",
-				"@jest/types": "^24.5.0",
+				"@jest/console": "^24.7.1",
+				"@jest/reporters": "^24.8.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.15",
-				"jest-changed-files": "^24.5.0",
-				"jest-config": "^24.5.0",
-				"jest-haste-map": "^24.5.0",
-				"jest-message-util": "^24.5.0",
+				"jest-changed-files": "^24.8.0",
+				"jest-config": "^24.8.0",
+				"jest-haste-map": "^24.8.0",
+				"jest-message-util": "^24.8.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-resolve-dependencies": "^24.5.0",
-				"jest-runner": "^24.5.0",
-				"jest-runtime": "^24.5.0",
-				"jest-snapshot": "^24.5.0",
-				"jest-util": "^24.5.0",
-				"jest-validate": "^24.5.0",
-				"jest-watcher": "^24.5.0",
+				"jest-resolve-dependencies": "^24.8.0",
+				"jest-runner": "^24.8.0",
+				"jest-runtime": "^24.8.0",
+				"jest-snapshot": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"jest-validate": "^24.8.0",
+				"jest-watcher": "^24.8.0",
 				"micromatch": "^3.1.10",
 				"p-each-series": "^1.0.0",
 				"pirates": "^4.0.1",
@@ -1001,6 +1027,73 @@
 				"strip-ansi": "^5.0.0"
 			},
 			"dependencies": {
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
 				"@cnakazawa/watch": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -1018,16 +1111,16 @@
 					"dev": true
 				},
 				"babel-jest": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.5.0.tgz",
-					"integrity": "sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
+					"integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
 					"dev": true,
 					"requires": {
-						"@jest/transform": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/transform": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"@types/babel__core": "^7.1.0",
 						"babel-plugin-istanbul": "^5.1.0",
-						"babel-preset-jest": "^24.3.0",
+						"babel-preset-jest": "^24.6.0",
 						"chalk": "^2.4.2",
 						"slash": "^2.0.0"
 					},
@@ -1046,45 +1139,45 @@
 					}
 				},
 				"babel-plugin-istanbul": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
-					"integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
+					"integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
 					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0",
-						"istanbul-lib-instrument": "^3.0.0",
-						"test-exclude": "^5.0.0"
+						"istanbul-lib-instrument": "^3.3.0",
+						"test-exclude": "^5.2.3"
 					}
 				},
 				"babel-plugin-jest-hoist": {
-					"version": "24.3.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz",
-					"integrity": "sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==",
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+					"integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
 					"dev": true,
 					"requires": {
 						"@types/babel__traverse": "^7.0.6"
 					}
 				},
 				"babel-preset-jest": {
-					"version": "24.3.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz",
-					"integrity": "sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==",
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+					"integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
 					"dev": true,
 					"requires": {
 						"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-						"babel-plugin-jest-hoist": "^24.3.0"
+						"babel-plugin-jest-hoist": "^24.6.0"
 					}
 				},
 				"callsites": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-					"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 					"dev": true
 				},
 				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
 				"capture-exit": {
@@ -1124,17 +1217,565 @@
 					}
 				},
 				"expect": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/expect/-/expect-24.5.0.tgz",
-					"integrity": "sha512-p2Gmc0CLxOgkyA93ySWmHFYHUPFIHG6XZ06l7WArWAsrqYVaVEkOU5NtT5i68KUyGKbkQgDCkiT65bWmdoL6Bw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
+					"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"ansi-styles": "^3.2.0",
-						"jest-get-type": "^24.3.0",
-						"jest-matcher-utils": "^24.5.0",
-						"jest-message-util": "^24.5.0",
+						"jest-get-type": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
 						"jest-regex-util": "^24.3.0"
+					}
+				},
+				"fsevents": {
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+					"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"nan": "^2.12.1",
+						"node-pre-gyp": "^0.12.0"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"deep-extend": {
+							"version": "0.6.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.24",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": ">= 2.1.2 < 3"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minipass": {
+							"version": "2.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.2.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.3.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"debug": "^4.1.0",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.12.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.1",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.2.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.4.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.6.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"dev": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.7.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.3.4",
+								"minizlib": "^1.1.1",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2 || 2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"yallist": {
+							"version": "3.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
 					}
 				},
 				"get-stream": {
@@ -1162,77 +1803,78 @@
 					}
 				},
 				"is-generator-fn": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
-					"integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+					"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 					"dev": true
 				},
 				"istanbul-lib-coverage": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-					"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+					"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
 					"dev": true
 				},
 				"istanbul-lib-instrument": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
-					"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+					"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
 					"dev": true,
 					"requires": {
-						"@babel/generator": "^7.0.0",
-						"@babel/parser": "^7.0.0",
-						"@babel/template": "^7.0.0",
-						"@babel/traverse": "^7.0.0",
-						"@babel/types": "^7.0.0",
-						"istanbul-lib-coverage": "^2.0.3",
-						"semver": "^5.5.0"
+						"@babel/generator": "^7.4.0",
+						"@babel/parser": "^7.4.3",
+						"@babel/template": "^7.4.0",
+						"@babel/traverse": "^7.4.3",
+						"@babel/types": "^7.4.0",
+						"istanbul-lib-coverage": "^2.0.5",
+						"semver": "^6.0.0"
 					}
 				},
 				"jest-changed-files": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.5.0.tgz",
-					"integrity": "sha512-Ikl29dosYnTsH9pYa1Tv9POkILBhN/TLZ37xbzgNsZ1D2+2n+8oEZS2yP1BrHn/T4Rs4Ggwwbp/x8CKOS5YJOg==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
+					"integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"execa": "^1.0.0",
 						"throat": "^4.0.0"
 					}
 				},
 				"jest-config": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.5.0.tgz",
-					"integrity": "sha512-t2UTh0Z2uZhGBNVseF8wA2DS2SuBiLOL6qpLq18+OZGfFUxTM7BzUVKyHFN/vuN+s/aslY1COW95j1Rw81huOQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
+					"integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
 					"dev": true,
 					"requires": {
 						"@babel/core": "^7.1.0",
-						"@jest/types": "^24.5.0",
-						"babel-jest": "^24.5.0",
+						"@jest/test-sequencer": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"babel-jest": "^24.8.0",
 						"chalk": "^2.0.1",
 						"glob": "^7.1.1",
-						"jest-environment-jsdom": "^24.5.0",
-						"jest-environment-node": "^24.5.0",
-						"jest-get-type": "^24.3.0",
-						"jest-jasmine2": "^24.5.0",
+						"jest-environment-jsdom": "^24.8.0",
+						"jest-environment-node": "^24.8.0",
+						"jest-get-type": "^24.8.0",
+						"jest-jasmine2": "^24.8.0",
 						"jest-regex-util": "^24.3.0",
-						"jest-resolve": "^24.5.0",
-						"jest-util": "^24.5.0",
-						"jest-validate": "^24.5.0",
+						"jest-resolve": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-validate": "^24.8.0",
 						"micromatch": "^3.1.10",
-						"pretty-format": "^24.5.0",
+						"pretty-format": "^24.8.0",
 						"realpath-native": "^1.1.0"
 					}
 				},
 				"jest-diff": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.5.0.tgz",
-					"integrity": "sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
+					"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"diff-sequences": "^24.3.0",
-						"jest-get-type": "^24.3.0",
-						"pretty-format": "^24.5.0"
+						"jest-get-type": "^24.8.0",
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-docblock": {
@@ -1245,122 +1887,125 @@
 					}
 				},
 				"jest-each": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.5.0.tgz",
-					"integrity": "sha512-6gy3Kh37PwIT5sNvNY2VchtIFOOBh8UCYnBlxXMb5sr5wpJUDPTUATX2Axq1Vfk+HWTMpsYPeVYp4TXx5uqUBw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
+					"integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"chalk": "^2.0.1",
-						"jest-get-type": "^24.3.0",
-						"jest-util": "^24.5.0",
-						"pretty-format": "^24.5.0"
+						"jest-get-type": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-environment-jsdom": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.5.0.tgz",
-					"integrity": "sha512-62Ih5HbdAWcsqBx2ktUnor/mABBo1U111AvZWcLKeWN/n/gc5ZvDBKe4Og44fQdHKiXClrNGC6G0mBo6wrPeGQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
+					"integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
 					"dev": true,
 					"requires": {
-						"@jest/environment": "^24.5.0",
-						"@jest/fake-timers": "^24.5.0",
-						"@jest/types": "^24.5.0",
-						"jest-mock": "^24.5.0",
-						"jest-util": "^24.5.0",
+						"@jest/environment": "^24.8.0",
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"jest-mock": "^24.8.0",
+						"jest-util": "^24.8.0",
 						"jsdom": "^11.5.1"
 					}
 				},
 				"jest-environment-node": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.5.0.tgz",
-					"integrity": "sha512-du6FuyWr/GbKLsmAbzNF9mpr2Iu2zWSaq/BNHzX+vgOcts9f2ayXBweS7RAhr+6bLp6qRpMB6utAMF5Ygktxnw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
+					"integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
 					"dev": true,
 					"requires": {
-						"@jest/environment": "^24.5.0",
-						"@jest/fake-timers": "^24.5.0",
-						"@jest/types": "^24.5.0",
-						"jest-mock": "^24.5.0",
-						"jest-util": "^24.5.0"
+						"@jest/environment": "^24.8.0",
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"jest-mock": "^24.8.0",
+						"jest-util": "^24.8.0"
 					}
 				},
 				"jest-get-type": {
-					"version": "24.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
-					"integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+					"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
 					"dev": true
 				},
 				"jest-haste-map": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.5.0.tgz",
-					"integrity": "sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
+					"integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
+						"anymatch": "^2.0.0",
 						"fb-watchman": "^2.0.0",
+						"fsevents": "^1.2.7",
 						"graceful-fs": "^4.1.15",
 						"invariant": "^2.2.4",
 						"jest-serializer": "^24.4.0",
-						"jest-util": "^24.5.0",
-						"jest-worker": "^24.4.0",
+						"jest-util": "^24.8.0",
+						"jest-worker": "^24.6.0",
 						"micromatch": "^3.1.10",
-						"sane": "^4.0.3"
+						"sane": "^4.0.3",
+						"walker": "^1.0.7"
 					}
 				},
 				"jest-jasmine2": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.5.0.tgz",
-					"integrity": "sha512-sfVrxVcx1rNUbBeyIyhkqZ4q+seNKyAG6iM0S2TYBdQsXjoFDdqWFfsUxb6uXSsbimbXX/NMkJIwUZ1uT9+/Aw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
+					"integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
 					"dev": true,
 					"requires": {
 						"@babel/traverse": "^7.1.0",
-						"@jest/environment": "^24.5.0",
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/environment": "^24.8.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"chalk": "^2.0.1",
 						"co": "^4.6.0",
-						"expect": "^24.5.0",
+						"expect": "^24.8.0",
 						"is-generator-fn": "^2.0.0",
-						"jest-each": "^24.5.0",
-						"jest-matcher-utils": "^24.5.0",
-						"jest-message-util": "^24.5.0",
-						"jest-runtime": "^24.5.0",
-						"jest-snapshot": "^24.5.0",
-						"jest-util": "^24.5.0",
-						"pretty-format": "^24.5.0",
+						"jest-each": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-runtime": "^24.8.0",
+						"jest-snapshot": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"pretty-format": "^24.8.0",
 						"throat": "^4.0.0"
 					}
 				},
 				"jest-leak-detector": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.5.0.tgz",
-					"integrity": "sha512-LZKBjGovFRx3cRBkqmIg+BZnxbrLqhQl09IziMk3oeh1OV81Hg30RUIx885mq8qBv1PA0comB9bjKcuyNO1bCQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
+					"integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
 					"dev": true,
 					"requires": {
-						"pretty-format": "^24.5.0"
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-matcher-utils": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz",
-					"integrity": "sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+					"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
-						"jest-diff": "^24.5.0",
-						"jest-get-type": "^24.3.0",
-						"pretty-format": "^24.5.0"
+						"jest-diff": "^24.8.0",
+						"jest-get-type": "^24.8.0",
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-message-util": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.5.0.tgz",
-					"integrity": "sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
+					"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"@types/stack-utils": "^1.0.1",
 						"chalk": "^2.0.1",
 						"micromatch": "^3.1.10",
@@ -1369,12 +2014,12 @@
 					}
 				},
 				"jest-mock": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.5.0.tgz",
-					"integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
+					"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0"
+						"@jest/types": "^24.8.0"
 					}
 				},
 				"jest-pnp-resolver": {
@@ -1390,12 +2035,12 @@
 					"dev": true
 				},
 				"jest-resolve": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.5.0.tgz",
-					"integrity": "sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+					"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"browser-resolve": "^1.11.3",
 						"chalk": "^2.0.1",
 						"jest-pnp-resolver": "^1.2.1",
@@ -1403,39 +2048,39 @@
 					}
 				},
 				"jest-resolve-dependencies": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.5.0.tgz",
-					"integrity": "sha512-dRVM1D+gWrFfrq2vlL5P9P/i8kB4BOYqYf3S7xczZ+A6PC3SgXYSErX/ScW/469pWMboM1uAhgLF+39nXlirCQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
+					"integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"jest-regex-util": "^24.3.0",
-						"jest-snapshot": "^24.5.0"
+						"jest-snapshot": "^24.8.0"
 					}
 				},
 				"jest-runner": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.5.0.tgz",
-					"integrity": "sha512-oqsiS9TkIZV5dVkD+GmbNfWBRPIvxqmlTQ+AQUJUQ07n+4xTSDc40r+aKBynHw9/tLzafC00DIbJjB2cOZdvMA==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
+					"integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
 					"dev": true,
 					"requires": {
-						"@jest/console": "^24.3.0",
-						"@jest/environment": "^24.5.0",
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/console": "^24.7.1",
+						"@jest/environment": "^24.8.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"chalk": "^2.4.2",
 						"exit": "^0.1.2",
 						"graceful-fs": "^4.1.15",
-						"jest-config": "^24.5.0",
+						"jest-config": "^24.8.0",
 						"jest-docblock": "^24.3.0",
-						"jest-haste-map": "^24.5.0",
-						"jest-jasmine2": "^24.5.0",
-						"jest-leak-detector": "^24.5.0",
-						"jest-message-util": "^24.5.0",
-						"jest-resolve": "^24.5.0",
-						"jest-runtime": "^24.5.0",
-						"jest-util": "^24.5.0",
-						"jest-worker": "^24.4.0",
+						"jest-haste-map": "^24.8.0",
+						"jest-jasmine2": "^24.8.0",
+						"jest-leak-detector": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-resolve": "^24.8.0",
+						"jest-runtime": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-worker": "^24.6.0",
 						"source-map-support": "^0.5.6",
 						"throat": "^4.0.0"
 					},
@@ -1454,30 +2099,30 @@
 					}
 				},
 				"jest-runtime": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.5.0.tgz",
-					"integrity": "sha512-GTFHzfLdwpaeoDPilNpBrorlPoNZuZrwKKzKJs09vWwHo+9TOsIIuszK8cWOuKC7ss07aN1922Ge8fsGdsqCuw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
+					"integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
 					"dev": true,
 					"requires": {
-						"@jest/console": "^24.3.0",
-						"@jest/environment": "^24.5.0",
+						"@jest/console": "^24.7.1",
+						"@jest/environment": "^24.8.0",
 						"@jest/source-map": "^24.3.0",
-						"@jest/transform": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/transform": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"@types/yargs": "^12.0.2",
 						"chalk": "^2.0.1",
 						"exit": "^0.1.2",
 						"glob": "^7.1.3",
 						"graceful-fs": "^4.1.15",
-						"jest-config": "^24.5.0",
-						"jest-haste-map": "^24.5.0",
-						"jest-message-util": "^24.5.0",
-						"jest-mock": "^24.5.0",
+						"jest-config": "^24.8.0",
+						"jest-haste-map": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-mock": "^24.8.0",
 						"jest-regex-util": "^24.3.0",
-						"jest-resolve": "^24.5.0",
-						"jest-snapshot": "^24.5.0",
-						"jest-util": "^24.5.0",
-						"jest-validate": "^24.5.0",
+						"jest-resolve": "^24.8.0",
+						"jest-snapshot": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-validate": "^24.8.0",
 						"realpath-native": "^1.1.0",
 						"slash": "^2.0.0",
 						"strip-bom": "^3.0.0",
@@ -1491,37 +2136,44 @@
 					"dev": true
 				},
 				"jest-snapshot": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.5.0.tgz",
-					"integrity": "sha512-eBEeJb5ROk0NcpodmSKnCVgMOo+Qsu5z9EDl3tGffwPzK1yV37mjGWF2YeIz1NkntgTzP+fUL4s09a0+0dpVWA==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
+					"integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
 					"dev": true,
 					"requires": {
 						"@babel/types": "^7.0.0",
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"chalk": "^2.0.1",
-						"expect": "^24.5.0",
-						"jest-diff": "^24.5.0",
-						"jest-matcher-utils": "^24.5.0",
-						"jest-message-util": "^24.5.0",
-						"jest-resolve": "^24.5.0",
+						"expect": "^24.8.0",
+						"jest-diff": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-resolve": "^24.8.0",
 						"mkdirp": "^0.5.1",
 						"natural-compare": "^1.4.0",
-						"pretty-format": "^24.5.0",
+						"pretty-format": "^24.8.0",
 						"semver": "^5.5.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+							"dev": true
+						}
 					}
 				},
 				"jest-util": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.5.0.tgz",
-					"integrity": "sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
+					"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
 					"dev": true,
 					"requires": {
-						"@jest/console": "^24.3.0",
-						"@jest/fake-timers": "^24.5.0",
+						"@jest/console": "^24.7.1",
+						"@jest/fake-timers": "^24.8.0",
 						"@jest/source-map": "^24.3.0",
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
-						"@types/node": "*",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"callsites": "^3.0.0",
 						"chalk": "^2.0.1",
 						"graceful-fs": "^4.1.15",
@@ -1529,45 +2181,51 @@
 						"mkdirp": "^0.5.1",
 						"slash": "^2.0.0",
 						"source-map": "^0.6.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"dev": true
+						}
 					}
 				},
 				"jest-validate": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
-					"integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
+					"integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"camelcase": "^5.0.0",
 						"chalk": "^2.0.1",
-						"jest-get-type": "^24.3.0",
+						"jest-get-type": "^24.8.0",
 						"leven": "^2.1.0",
-						"pretty-format": "^24.5.0"
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-watcher": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.5.0.tgz",
-					"integrity": "sha512-/hCpgR6bg0nKvD3nv4KasdTxuhwfViVMHUATJlnGCD0r1QrmIssimPbmc5KfAQblAVxkD8xrzuij9vfPUk1/rA==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.8.0.tgz",
+					"integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
 					"dev": true,
 					"requires": {
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
-						"@types/node": "*",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"@types/yargs": "^12.0.9",
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.1",
-						"jest-util": "^24.5.0",
+						"jest-util": "^24.8.0",
 						"string-length": "^2.0.0"
 					}
 				},
 				"jest-worker": {
-					"version": "24.4.0",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
-					"integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+					"integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
 					"dev": true,
 					"requires": {
-						"@types/node": "*",
 						"merge-stream": "^1.0.1",
 						"supports-color": "^6.1.0"
 					},
@@ -1601,6 +2259,13 @@
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
+				"nan": {
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+					"dev": true,
+					"optional": true
+				},
 				"path-type": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -1617,12 +2282,12 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
-					"integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+					"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"ansi-regex": "^4.0.0",
 						"ansi-styles": "^3.2.0",
 						"react-is": "^16.8.4"
@@ -1649,6 +2314,12 @@
 						"read-pkg": "^3.0.0"
 					}
 				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
 				"rsvp": {
 					"version": "4.8.4",
 					"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
@@ -1672,32 +2343,40 @@
 						"walker": "~1.0.5"
 					}
 				},
+				"semver": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+					"dev": true
+				},
 				"slash": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
 					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
 					"dev": true
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
 				"source-map-support": {
-					"version": "0.5.11",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
-					"integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+					"version": "0.5.12",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+					"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
 					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"source-map": "^0.6.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"dev": true
+						}
 					}
 				},
 				"strip-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
-					"integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
@@ -1719,64 +2398,62 @@
 					}
 				},
 				"test-exclude": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
-					"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+					"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
 					"dev": true,
 					"requires": {
-						"arrify": "^1.0.1",
+						"glob": "^7.1.3",
 						"minimatch": "^3.0.4",
 						"read-pkg-up": "^4.0.0",
-						"require-main-filename": "^1.0.1"
+						"require-main-filename": "^2.0.0"
 					}
 				}
 			}
 		},
 		"@jest/environment": {
-			"version": "24.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.5.0.tgz",
-			"integrity": "sha512-tzUHR9SHjMXwM8QmfHb/EJNbF0fjbH4ieefJBvtwO8YErLTrecc1ROj0uo2VnIT6SlpEGZnvdCK6VgKYBo8LsA==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
+			"integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^24.5.0",
-				"@jest/transform": "^24.5.0",
-				"@jest/types": "^24.5.0",
-				"@types/node": "*",
-				"jest-mock": "^24.5.0"
+				"@jest/fake-timers": "^24.8.0",
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"jest-mock": "^24.8.0"
 			},
 			"dependencies": {
 				"jest-mock": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.5.0.tgz",
-					"integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
+					"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0"
+						"@jest/types": "^24.8.0"
 					}
 				}
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "24.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.5.0.tgz",
-			"integrity": "sha512-i59KVt3QBz9d+4Qr4QxsKgsIg+NjfuCjSOWj3RQhjF5JNy+eVJDhANQ4WzulzNCHd72srMAykwtRn5NYDGVraw==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
+			"integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.5.0",
-				"@types/node": "*",
-				"jest-message-util": "^24.5.0",
-				"jest-mock": "^24.5.0"
+				"@jest/types": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-mock": "^24.8.0"
 			},
 			"dependencies": {
 				"jest-message-util": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.5.0.tgz",
-					"integrity": "sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
+					"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"@types/stack-utils": "^1.0.1",
 						"chalk": "^2.0.1",
 						"micromatch": "^3.1.10",
@@ -1785,12 +2462,12 @@
 					}
 				},
 				"jest-mock": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.5.0.tgz",
-					"integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
+					"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0"
+						"@jest/types": "^24.8.0"
 					}
 				},
 				"slash": {
@@ -1802,33 +2479,109 @@
 			}
 		},
 		"@jest/reporters": {
-			"version": "24.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.5.0.tgz",
-			"integrity": "sha512-vfpceiaKtGgnuC3ss5czWOihKOUSyjJA4M4udm6nH8xgqsuQYcyDCi4nMMcBKsHXWgz9/V5G7iisnZGfOh1w6Q==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
+			"integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.5.0",
-				"@jest/test-result": "^24.5.0",
-				"@jest/transform": "^24.5.0",
-				"@jest/types": "^24.5.0",
+				"@jest/environment": "^24.8.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/transform": "^24.8.0",
+				"@jest/types": "^24.8.0",
 				"chalk": "^2.0.1",
 				"exit": "^0.1.2",
 				"glob": "^7.1.2",
-				"istanbul-api": "^2.1.1",
 				"istanbul-lib-coverage": "^2.0.2",
 				"istanbul-lib-instrument": "^3.0.1",
+				"istanbul-lib-report": "^2.0.4",
 				"istanbul-lib-source-maps": "^3.0.1",
-				"jest-haste-map": "^24.5.0",
-				"jest-resolve": "^24.5.0",
-				"jest-runtime": "^24.5.0",
-				"jest-util": "^24.5.0",
-				"jest-worker": "^24.4.0",
+				"istanbul-reports": "^2.1.1",
+				"jest-haste-map": "^24.8.0",
+				"jest-resolve": "^24.8.0",
+				"jest-runtime": "^24.8.0",
+				"jest-util": "^24.8.0",
+				"jest-worker": "^24.6.0",
 				"node-notifier": "^5.2.1",
 				"slash": "^2.0.0",
 				"source-map": "^0.6.0",
 				"string-length": "^2.0.0"
 			},
 			"dependencies": {
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
 				"@cnakazawa/watch": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -1845,26 +2598,17 @@
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
-				"append-transform": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-					"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
-					"dev": true,
-					"requires": {
-						"default-require-extensions": "^2.0.0"
-					}
-				},
 				"babel-jest": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.5.0.tgz",
-					"integrity": "sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
+					"integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
 					"dev": true,
 					"requires": {
-						"@jest/transform": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/transform": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"@types/babel__core": "^7.1.0",
 						"babel-plugin-istanbul": "^5.1.0",
-						"babel-preset-jest": "^24.3.0",
+						"babel-preset-jest": "^24.6.0",
 						"chalk": "^2.4.2",
 						"slash": "^2.0.0"
 					},
@@ -1892,45 +2636,45 @@
 					}
 				},
 				"babel-plugin-istanbul": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
-					"integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
+					"integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
 					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0",
-						"istanbul-lib-instrument": "^3.0.0",
-						"test-exclude": "^5.0.0"
+						"istanbul-lib-instrument": "^3.3.0",
+						"test-exclude": "^5.2.3"
 					}
 				},
 				"babel-plugin-jest-hoist": {
-					"version": "24.3.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz",
-					"integrity": "sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==",
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+					"integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
 					"dev": true,
 					"requires": {
 						"@types/babel__traverse": "^7.0.6"
 					}
 				},
 				"babel-preset-jest": {
-					"version": "24.3.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz",
-					"integrity": "sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==",
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+					"integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
 					"dev": true,
 					"requires": {
 						"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-						"babel-plugin-jest-hoist": "^24.3.0"
+						"babel-plugin-jest-hoist": "^24.6.0"
 					}
 				},
 				"callsites": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-					"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 					"dev": true
 				},
 				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
 				"capture-exit": {
@@ -1947,15 +2691,6 @@
 					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
 					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
 					"dev": true
-				},
-				"default-require-extensions": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-					"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
-					"dev": true,
-					"requires": {
-						"strip-bom": "^3.0.0"
-					}
 				},
 				"exec-sh": {
 					"version": "0.3.2",
@@ -1979,17 +2714,1964 @@
 					}
 				},
 				"expect": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/expect/-/expect-24.5.0.tgz",
-					"integrity": "sha512-p2Gmc0CLxOgkyA93ySWmHFYHUPFIHG6XZ06l7WArWAsrqYVaVEkOU5NtT5i68KUyGKbkQgDCkiT65bWmdoL6Bw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
+					"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"ansi-styles": "^3.2.0",
-						"jest-get-type": "^24.3.0",
-						"jest-matcher-utils": "^24.5.0",
-						"jest-message-util": "^24.5.0",
+						"jest-get-type": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
 						"jest-regex-util": "^24.3.0"
+					}
+				},
+				"fsevents": {
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+					"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"nan": "^2.12.1",
+						"node-pre-gyp": "^0.12.0"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"deep-extend": {
+							"version": "0.6.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.24",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": ">= 2.1.2 < 3"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minipass": {
+							"version": "2.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.2.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.3.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"debug": "^4.1.0",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.12.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.1",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.2.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.4.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.6.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"dev": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.7.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.3.4",
+								"minizlib": "^1.1.1",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2 || 2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"yallist": {
+							"version": "3.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"dev": true
+				},
+				"handlebars": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+					"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+					"dev": true,
+					"requires": {
+						"neo-async": "^2.6.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.6.1",
+						"uglify-js": "^3.1.4"
+					}
+				},
+				"is-ci": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+					"dev": true,
+					"requires": {
+						"ci-info": "^2.0.0"
+					}
+				},
+				"is-generator-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+					"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+					"dev": true
+				},
+				"istanbul-lib-coverage": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+					"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+					"dev": true
+				},
+				"istanbul-lib-instrument": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+					"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+					"dev": true,
+					"requires": {
+						"@babel/generator": "^7.4.0",
+						"@babel/parser": "^7.4.3",
+						"@babel/template": "^7.4.0",
+						"@babel/traverse": "^7.4.3",
+						"@babel/types": "^7.4.0",
+						"istanbul-lib-coverage": "^2.0.5",
+						"semver": "^6.0.0"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "2.0.8",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+					"integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+					"dev": true,
+					"requires": {
+						"istanbul-lib-coverage": "^2.0.5",
+						"make-dir": "^2.1.0",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "3.0.6",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+					"integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.1.1",
+						"istanbul-lib-coverage": "^2.0.5",
+						"make-dir": "^2.1.0",
+						"rimraf": "^2.6.3",
+						"source-map": "^0.6.1"
+					}
+				},
+				"istanbul-reports": {
+					"version": "2.2.6",
+					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+					"integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+					"dev": true,
+					"requires": {
+						"handlebars": "^4.1.2"
+					}
+				},
+				"jest-config": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
+					"integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.1.0",
+						"@jest/test-sequencer": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"babel-jest": "^24.8.0",
+						"chalk": "^2.0.1",
+						"glob": "^7.1.1",
+						"jest-environment-jsdom": "^24.8.0",
+						"jest-environment-node": "^24.8.0",
+						"jest-get-type": "^24.8.0",
+						"jest-jasmine2": "^24.8.0",
+						"jest-regex-util": "^24.3.0",
+						"jest-resolve": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-validate": "^24.8.0",
+						"micromatch": "^3.1.10",
+						"pretty-format": "^24.8.0",
+						"realpath-native": "^1.1.0"
+					}
+				},
+				"jest-diff": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
+					"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff-sequences": "^24.3.0",
+						"jest-get-type": "^24.8.0",
+						"pretty-format": "^24.8.0"
+					}
+				},
+				"jest-each": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
+					"integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"chalk": "^2.0.1",
+						"jest-get-type": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"pretty-format": "^24.8.0"
+					}
+				},
+				"jest-environment-jsdom": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
+					"integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^24.8.0",
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"jest-mock": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jsdom": "^11.5.1"
+					}
+				},
+				"jest-environment-node": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
+					"integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^24.8.0",
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"jest-mock": "^24.8.0",
+						"jest-util": "^24.8.0"
+					}
+				},
+				"jest-get-type": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+					"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+					"dev": true
+				},
+				"jest-haste-map": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
+					"integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"anymatch": "^2.0.0",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^1.2.7",
+						"graceful-fs": "^4.1.15",
+						"invariant": "^2.2.4",
+						"jest-serializer": "^24.4.0",
+						"jest-util": "^24.8.0",
+						"jest-worker": "^24.6.0",
+						"micromatch": "^3.1.10",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7"
+					}
+				},
+				"jest-jasmine2": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
+					"integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
+					"dev": true,
+					"requires": {
+						"@babel/traverse": "^7.1.0",
+						"@jest/environment": "^24.8.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"chalk": "^2.0.1",
+						"co": "^4.6.0",
+						"expect": "^24.8.0",
+						"is-generator-fn": "^2.0.0",
+						"jest-each": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-runtime": "^24.8.0",
+						"jest-snapshot": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"pretty-format": "^24.8.0",
+						"throat": "^4.0.0"
+					}
+				},
+				"jest-matcher-utils": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+					"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-diff": "^24.8.0",
+						"jest-get-type": "^24.8.0",
+						"pretty-format": "^24.8.0"
+					}
+				},
+				"jest-message-util": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
+					"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"@types/stack-utils": "^1.0.1",
+						"chalk": "^2.0.1",
+						"micromatch": "^3.1.10",
+						"slash": "^2.0.0",
+						"stack-utils": "^1.0.1"
+					}
+				},
+				"jest-mock": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
+					"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0"
+					}
+				},
+				"jest-pnp-resolver": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+					"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+					"dev": true
+				},
+				"jest-regex-util": {
+					"version": "24.3.0",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+					"integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+					"dev": true
+				},
+				"jest-resolve": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+					"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"browser-resolve": "^1.11.3",
+						"chalk": "^2.0.1",
+						"jest-pnp-resolver": "^1.2.1",
+						"realpath-native": "^1.1.0"
+					}
+				},
+				"jest-runtime": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
+					"integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.7.1",
+						"@jest/environment": "^24.8.0",
+						"@jest/source-map": "^24.3.0",
+						"@jest/transform": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"@types/yargs": "^12.0.2",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.1.15",
+						"jest-config": "^24.8.0",
+						"jest-haste-map": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-mock": "^24.8.0",
+						"jest-regex-util": "^24.3.0",
+						"jest-resolve": "^24.8.0",
+						"jest-snapshot": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-validate": "^24.8.0",
+						"realpath-native": "^1.1.0",
+						"slash": "^2.0.0",
+						"strip-bom": "^3.0.0",
+						"yargs": "^12.0.2"
+					}
+				},
+				"jest-serializer": {
+					"version": "24.4.0",
+					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+					"integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
+					"dev": true
+				},
+				"jest-snapshot": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
+					"integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^24.8.0",
+						"chalk": "^2.0.1",
+						"expect": "^24.8.0",
+						"jest-diff": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-resolve": "^24.8.0",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^24.8.0",
+						"semver": "^5.5.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+							"dev": true
+						}
+					}
+				},
+				"jest-util": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
+					"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.7.1",
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/source-map": "^24.3.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"callsites": "^3.0.0",
+						"chalk": "^2.0.1",
+						"graceful-fs": "^4.1.15",
+						"is-ci": "^2.0.0",
+						"mkdirp": "^0.5.1",
+						"slash": "^2.0.0",
+						"source-map": "^0.6.0"
+					}
+				},
+				"jest-validate": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
+					"integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"camelcase": "^5.0.0",
+						"chalk": "^2.0.1",
+						"jest-get-type": "^24.8.0",
+						"leven": "^2.1.0",
+						"pretty-format": "^24.8.0"
+					}
+				},
+				"jest-worker": {
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+					"integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
+					"dev": true,
+					"requires": {
+						"merge-stream": "^1.0.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+							"dev": true
+						}
+					}
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+							"dev": true
+						}
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"nan": {
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+					"dev": true,
+					"optional": true
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+							"dev": true
+						}
+					}
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+					"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"ansi-regex": "^4.0.0",
+						"ansi-styles": "^3.2.0",
+						"react-is": "^16.8.4"
+					}
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"rsvp": {
+					"version": "4.8.4",
+					"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+					"integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+					"dev": true
+				},
+				"sane": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+					"integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+					"dev": true,
+					"requires": {
+						"@cnakazawa/watch": "^1.0.3",
+						"anymatch": "^2.0.0",
+						"capture-exit": "^2.0.0",
+						"exec-sh": "^0.3.2",
+						"execa": "^1.0.0",
+						"fb-watchman": "^2.0.0",
+						"micromatch": "^3.1.4",
+						"minimist": "^1.1.1",
+						"walker": "~1.0.5"
+					}
+				},
+				"semver": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+					"dev": true
+				},
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"test-exclude": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+					"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3",
+						"minimatch": "^3.0.4",
+						"read-pkg-up": "^4.0.0",
+						"require-main-filename": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@jest/source-map": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.1.15",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"callsites": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+					"dev": true
+				},
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"@jest/test-result": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
+			"integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.7.1",
+				"@jest/types": "^24.8.0",
+				"@types/istanbul-lib-coverage": "^2.0.0"
+			}
+		},
+		"@jest/test-sequencer": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
+			"integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^24.8.0",
+				"jest-haste-map": "^24.8.0",
+				"jest-runner": "^24.8.0",
+				"jest-runtime": "^24.8.0"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"@cnakazawa/watch": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+					"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+					"dev": true,
+					"requires": {
+						"exec-sh": "^0.3.2",
+						"minimist": "^1.2.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"babel-jest": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
+					"integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
+					"dev": true,
+					"requires": {
+						"@jest/transform": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"@types/babel__core": "^7.1.0",
+						"babel-plugin-istanbul": "^5.1.0",
+						"babel-preset-jest": "^24.6.0",
+						"chalk": "^2.4.2",
+						"slash": "^2.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"babel-plugin-istanbul": {
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
+					"integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0",
+						"istanbul-lib-instrument": "^3.3.0",
+						"test-exclude": "^5.2.3"
+					}
+				},
+				"babel-plugin-jest-hoist": {
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+					"integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
+					"dev": true,
+					"requires": {
+						"@types/babel__traverse": "^7.0.6"
+					}
+				},
+				"babel-preset-jest": {
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+					"integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
+					"dev": true,
+					"requires": {
+						"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+						"babel-plugin-jest-hoist": "^24.6.0"
+					}
+				},
+				"callsites": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"capture-exit": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+					"integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+					"dev": true,
+					"requires": {
+						"rsvp": "^4.8.4"
+					}
+				},
+				"ci-info": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+					"dev": true
+				},
+				"exec-sh": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+					"integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+					"dev": true
+				},
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"expect": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
+					"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"ansi-styles": "^3.2.0",
+						"jest-get-type": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-regex-util": "^24.3.0"
+					}
+				},
+				"fsevents": {
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+					"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"nan": "^2.12.1",
+						"node-pre-gyp": "^0.12.0"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"deep-extend": {
+							"version": "0.6.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.24",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": ">= 2.1.2 < 3"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minipass": {
+							"version": "2.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.2.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.3.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"debug": "^4.1.0",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.12.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.1",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.2.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.4.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.6.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"dev": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.7.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.3.4",
+								"minizlib": "^1.1.1",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2 || 2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"yallist": {
+							"version": "3.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
 					}
 				},
 				"get-stream": {
@@ -2017,239 +4699,198 @@
 					}
 				},
 				"is-generator-fn": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
-					"integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+					"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 					"dev": true
-				},
-				"istanbul-api": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
-					"integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
-					"dev": true,
-					"requires": {
-						"async": "^2.6.1",
-						"compare-versions": "^3.2.1",
-						"fileset": "^2.0.3",
-						"istanbul-lib-coverage": "^2.0.3",
-						"istanbul-lib-hook": "^2.0.3",
-						"istanbul-lib-instrument": "^3.1.0",
-						"istanbul-lib-report": "^2.0.4",
-						"istanbul-lib-source-maps": "^3.0.2",
-						"istanbul-reports": "^2.1.1",
-						"js-yaml": "^3.12.0",
-						"make-dir": "^1.3.0",
-						"minimatch": "^3.0.4",
-						"once": "^1.4.0"
-					}
 				},
 				"istanbul-lib-coverage": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-					"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+					"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
 					"dev": true
 				},
-				"istanbul-lib-hook": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
-					"integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
-					"dev": true,
-					"requires": {
-						"append-transform": "^1.0.0"
-					}
-				},
 				"istanbul-lib-instrument": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
-					"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+					"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
 					"dev": true,
 					"requires": {
-						"@babel/generator": "^7.0.0",
-						"@babel/parser": "^7.0.0",
-						"@babel/template": "^7.0.0",
-						"@babel/traverse": "^7.0.0",
-						"@babel/types": "^7.0.0",
-						"istanbul-lib-coverage": "^2.0.3",
-						"semver": "^5.5.0"
-					}
-				},
-				"istanbul-lib-report": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
-					"integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
-					"dev": true,
-					"requires": {
-						"istanbul-lib-coverage": "^2.0.3",
-						"make-dir": "^1.3.0",
-						"supports-color": "^6.0.0"
-					}
-				},
-				"istanbul-lib-source-maps": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
-					"integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
-					"dev": true,
-					"requires": {
-						"debug": "^4.1.1",
-						"istanbul-lib-coverage": "^2.0.3",
-						"make-dir": "^1.3.0",
-						"rimraf": "^2.6.2",
-						"source-map": "^0.6.1"
-					}
-				},
-				"istanbul-reports": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
-					"integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
-					"dev": true,
-					"requires": {
-						"handlebars": "^4.1.0"
+						"@babel/generator": "^7.4.0",
+						"@babel/parser": "^7.4.3",
+						"@babel/template": "^7.4.0",
+						"@babel/traverse": "^7.4.3",
+						"@babel/types": "^7.4.0",
+						"istanbul-lib-coverage": "^2.0.5",
+						"semver": "^6.0.0"
 					}
 				},
 				"jest-config": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.5.0.tgz",
-					"integrity": "sha512-t2UTh0Z2uZhGBNVseF8wA2DS2SuBiLOL6qpLq18+OZGfFUxTM7BzUVKyHFN/vuN+s/aslY1COW95j1Rw81huOQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
+					"integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
 					"dev": true,
 					"requires": {
 						"@babel/core": "^7.1.0",
-						"@jest/types": "^24.5.0",
-						"babel-jest": "^24.5.0",
+						"@jest/test-sequencer": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"babel-jest": "^24.8.0",
 						"chalk": "^2.0.1",
 						"glob": "^7.1.1",
-						"jest-environment-jsdom": "^24.5.0",
-						"jest-environment-node": "^24.5.0",
-						"jest-get-type": "^24.3.0",
-						"jest-jasmine2": "^24.5.0",
+						"jest-environment-jsdom": "^24.8.0",
+						"jest-environment-node": "^24.8.0",
+						"jest-get-type": "^24.8.0",
+						"jest-jasmine2": "^24.8.0",
 						"jest-regex-util": "^24.3.0",
-						"jest-resolve": "^24.5.0",
-						"jest-util": "^24.5.0",
-						"jest-validate": "^24.5.0",
+						"jest-resolve": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-validate": "^24.8.0",
 						"micromatch": "^3.1.10",
-						"pretty-format": "^24.5.0",
+						"pretty-format": "^24.8.0",
 						"realpath-native": "^1.1.0"
 					}
 				},
 				"jest-diff": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.5.0.tgz",
-					"integrity": "sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
+					"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"diff-sequences": "^24.3.0",
-						"jest-get-type": "^24.3.0",
-						"pretty-format": "^24.5.0"
+						"jest-get-type": "^24.8.0",
+						"pretty-format": "^24.8.0"
+					}
+				},
+				"jest-docblock": {
+					"version": "24.3.0",
+					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+					"integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
+					"dev": true,
+					"requires": {
+						"detect-newline": "^2.1.0"
 					}
 				},
 				"jest-each": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.5.0.tgz",
-					"integrity": "sha512-6gy3Kh37PwIT5sNvNY2VchtIFOOBh8UCYnBlxXMb5sr5wpJUDPTUATX2Axq1Vfk+HWTMpsYPeVYp4TXx5uqUBw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
+					"integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"chalk": "^2.0.1",
-						"jest-get-type": "^24.3.0",
-						"jest-util": "^24.5.0",
-						"pretty-format": "^24.5.0"
+						"jest-get-type": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-environment-jsdom": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.5.0.tgz",
-					"integrity": "sha512-62Ih5HbdAWcsqBx2ktUnor/mABBo1U111AvZWcLKeWN/n/gc5ZvDBKe4Og44fQdHKiXClrNGC6G0mBo6wrPeGQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
+					"integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
 					"dev": true,
 					"requires": {
-						"@jest/environment": "^24.5.0",
-						"@jest/fake-timers": "^24.5.0",
-						"@jest/types": "^24.5.0",
-						"jest-mock": "^24.5.0",
-						"jest-util": "^24.5.0",
+						"@jest/environment": "^24.8.0",
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"jest-mock": "^24.8.0",
+						"jest-util": "^24.8.0",
 						"jsdom": "^11.5.1"
 					}
 				},
 				"jest-environment-node": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.5.0.tgz",
-					"integrity": "sha512-du6FuyWr/GbKLsmAbzNF9mpr2Iu2zWSaq/BNHzX+vgOcts9f2ayXBweS7RAhr+6bLp6qRpMB6utAMF5Ygktxnw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
+					"integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
 					"dev": true,
 					"requires": {
-						"@jest/environment": "^24.5.0",
-						"@jest/fake-timers": "^24.5.0",
-						"@jest/types": "^24.5.0",
-						"jest-mock": "^24.5.0",
-						"jest-util": "^24.5.0"
+						"@jest/environment": "^24.8.0",
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"jest-mock": "^24.8.0",
+						"jest-util": "^24.8.0"
 					}
 				},
 				"jest-get-type": {
-					"version": "24.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
-					"integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+					"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
 					"dev": true
 				},
 				"jest-haste-map": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.5.0.tgz",
-					"integrity": "sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
+					"integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
+						"anymatch": "^2.0.0",
 						"fb-watchman": "^2.0.0",
+						"fsevents": "^1.2.7",
 						"graceful-fs": "^4.1.15",
 						"invariant": "^2.2.4",
 						"jest-serializer": "^24.4.0",
-						"jest-util": "^24.5.0",
-						"jest-worker": "^24.4.0",
+						"jest-util": "^24.8.0",
+						"jest-worker": "^24.6.0",
 						"micromatch": "^3.1.10",
-						"sane": "^4.0.3"
+						"sane": "^4.0.3",
+						"walker": "^1.0.7"
 					}
 				},
 				"jest-jasmine2": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.5.0.tgz",
-					"integrity": "sha512-sfVrxVcx1rNUbBeyIyhkqZ4q+seNKyAG6iM0S2TYBdQsXjoFDdqWFfsUxb6uXSsbimbXX/NMkJIwUZ1uT9+/Aw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
+					"integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
 					"dev": true,
 					"requires": {
 						"@babel/traverse": "^7.1.0",
-						"@jest/environment": "^24.5.0",
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/environment": "^24.8.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"chalk": "^2.0.1",
 						"co": "^4.6.0",
-						"expect": "^24.5.0",
+						"expect": "^24.8.0",
 						"is-generator-fn": "^2.0.0",
-						"jest-each": "^24.5.0",
-						"jest-matcher-utils": "^24.5.0",
-						"jest-message-util": "^24.5.0",
-						"jest-runtime": "^24.5.0",
-						"jest-snapshot": "^24.5.0",
-						"jest-util": "^24.5.0",
-						"pretty-format": "^24.5.0",
+						"jest-each": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-runtime": "^24.8.0",
+						"jest-snapshot": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"pretty-format": "^24.8.0",
 						"throat": "^4.0.0"
 					}
 				},
+				"jest-leak-detector": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
+					"integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
+					"dev": true,
+					"requires": {
+						"pretty-format": "^24.8.0"
+					}
+				},
 				"jest-matcher-utils": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz",
-					"integrity": "sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+					"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
-						"jest-diff": "^24.5.0",
-						"jest-get-type": "^24.3.0",
-						"pretty-format": "^24.5.0"
+						"jest-diff": "^24.8.0",
+						"jest-get-type": "^24.8.0",
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-message-util": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.5.0.tgz",
-					"integrity": "sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
+					"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"@types/stack-utils": "^1.0.1",
 						"chalk": "^2.0.1",
 						"micromatch": "^3.1.10",
@@ -2258,12 +4899,12 @@
 					}
 				},
 				"jest-mock": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.5.0.tgz",
-					"integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
+					"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0"
+						"@jest/types": "^24.8.0"
 					}
 				},
 				"jest-pnp-resolver": {
@@ -2279,43 +4920,92 @@
 					"dev": true
 				},
 				"jest-resolve": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.5.0.tgz",
-					"integrity": "sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+					"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"browser-resolve": "^1.11.3",
 						"chalk": "^2.0.1",
 						"jest-pnp-resolver": "^1.2.1",
 						"realpath-native": "^1.1.0"
 					}
 				},
-				"jest-runtime": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.5.0.tgz",
-					"integrity": "sha512-GTFHzfLdwpaeoDPilNpBrorlPoNZuZrwKKzKJs09vWwHo+9TOsIIuszK8cWOuKC7ss07aN1922Ge8fsGdsqCuw==",
+				"jest-runner": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
+					"integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
 					"dev": true,
 					"requires": {
-						"@jest/console": "^24.3.0",
-						"@jest/environment": "^24.5.0",
+						"@jest/console": "^24.7.1",
+						"@jest/environment": "^24.8.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"chalk": "^2.4.2",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.1.15",
+						"jest-config": "^24.8.0",
+						"jest-docblock": "^24.3.0",
+						"jest-haste-map": "^24.8.0",
+						"jest-jasmine2": "^24.8.0",
+						"jest-leak-detector": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-resolve": "^24.8.0",
+						"jest-runtime": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-worker": "^24.6.0",
+						"source-map-support": "^0.5.6",
+						"throat": "^4.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-runtime": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
+					"integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.7.1",
+						"@jest/environment": "^24.8.0",
 						"@jest/source-map": "^24.3.0",
-						"@jest/transform": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/transform": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"@types/yargs": "^12.0.2",
 						"chalk": "^2.0.1",
 						"exit": "^0.1.2",
 						"glob": "^7.1.3",
 						"graceful-fs": "^4.1.15",
-						"jest-config": "^24.5.0",
-						"jest-haste-map": "^24.5.0",
-						"jest-message-util": "^24.5.0",
-						"jest-mock": "^24.5.0",
+						"jest-config": "^24.8.0",
+						"jest-haste-map": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-mock": "^24.8.0",
 						"jest-regex-util": "^24.3.0",
-						"jest-resolve": "^24.5.0",
-						"jest-snapshot": "^24.5.0",
-						"jest-util": "^24.5.0",
-						"jest-validate": "^24.5.0",
+						"jest-resolve": "^24.8.0",
+						"jest-snapshot": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-validate": "^24.8.0",
 						"realpath-native": "^1.1.0",
 						"slash": "^2.0.0",
 						"strip-bom": "^3.0.0",
@@ -2329,37 +5019,44 @@
 					"dev": true
 				},
 				"jest-snapshot": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.5.0.tgz",
-					"integrity": "sha512-eBEeJb5ROk0NcpodmSKnCVgMOo+Qsu5z9EDl3tGffwPzK1yV37mjGWF2YeIz1NkntgTzP+fUL4s09a0+0dpVWA==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
+					"integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
 					"dev": true,
 					"requires": {
 						"@babel/types": "^7.0.0",
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"chalk": "^2.0.1",
-						"expect": "^24.5.0",
-						"jest-diff": "^24.5.0",
-						"jest-matcher-utils": "^24.5.0",
-						"jest-message-util": "^24.5.0",
-						"jest-resolve": "^24.5.0",
+						"expect": "^24.8.0",
+						"jest-diff": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-resolve": "^24.8.0",
 						"mkdirp": "^0.5.1",
 						"natural-compare": "^1.4.0",
-						"pretty-format": "^24.5.0",
+						"pretty-format": "^24.8.0",
 						"semver": "^5.5.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+							"dev": true
+						}
 					}
 				},
 				"jest-util": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.5.0.tgz",
-					"integrity": "sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
+					"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
 					"dev": true,
 					"requires": {
-						"@jest/console": "^24.3.0",
-						"@jest/fake-timers": "^24.5.0",
+						"@jest/console": "^24.7.1",
+						"@jest/fake-timers": "^24.8.0",
 						"@jest/source-map": "^24.3.0",
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
-						"@types/node": "*",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"callsites": "^3.0.0",
 						"chalk": "^2.0.1",
 						"graceful-fs": "^4.1.15",
@@ -2370,26 +5067,25 @@
 					}
 				},
 				"jest-validate": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
-					"integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
+					"integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"camelcase": "^5.0.0",
 						"chalk": "^2.0.1",
-						"jest-get-type": "^24.3.0",
+						"jest-get-type": "^24.8.0",
 						"leven": "^2.1.0",
-						"pretty-format": "^24.5.0"
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-worker": {
-					"version": "24.4.0",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
-					"integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+					"integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
 					"dev": true,
 					"requires": {
-						"@types/node": "*",
 						"merge-stream": "^1.0.1",
 						"supports-color": "^6.1.0"
 					}
@@ -2412,6 +5108,13 @@
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
+				"nan": {
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+					"dev": true,
+					"optional": true
+				},
 				"path-type": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -2428,12 +5131,12 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
-					"integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+					"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"ansi-regex": "^4.0.0",
 						"ansi-styles": "^3.2.0",
 						"react-is": "^16.8.4"
@@ -2460,6 +5163,12 @@
 						"read-pkg": "^3.0.0"
 					}
 				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
 				"rsvp": {
 					"version": "4.8.4",
 					"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
@@ -2483,6 +5192,12 @@
 						"walker": "~1.0.5"
 					}
 				},
+				"semver": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+					"dev": true
+				},
 				"slash": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -2494,6 +5209,16 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
+				},
+				"source-map-support": {
+					"version": "0.5.12",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+					"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+					"dev": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
 				},
 				"strip-bom": {
 					"version": "3.0.0",
@@ -2511,77 +5236,35 @@
 					}
 				},
 				"test-exclude": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
-					"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+					"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
 					"dev": true,
 					"requires": {
-						"arrify": "^1.0.1",
+						"glob": "^7.1.3",
 						"minimatch": "^3.0.4",
 						"read-pkg-up": "^4.0.0",
-						"require-main-filename": "^1.0.1"
+						"require-main-filename": "^2.0.0"
 					}
 				}
 			}
 		},
-		"@jest/source-map": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
-			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
-			"dev": true,
-			"requires": {
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.1.15",
-				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"callsites": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-					"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
-					"dev": true
-				},
-				"graceful-fs": {
-					"version": "4.1.15",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"@jest/test-result": {
-			"version": "24.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.5.0.tgz",
-			"integrity": "sha512-u66j2vBfa8Bli1+o3rCaVnVYa9O8CAFZeqiqLVhnarXtreSXG33YQ6vNYBogT7+nYiFNOohTU21BKiHlgmxD5A==",
-			"dev": true,
-			"requires": {
-				"@jest/console": "^24.3.0",
-				"@jest/types": "^24.5.0",
-				"@types/istanbul-lib-coverage": "^1.1.0"
-			}
-		},
 		"@jest/transform": {
-			"version": "24.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.5.0.tgz",
-			"integrity": "sha512-XSsDz1gdR/QMmB8UCKlweAReQsZrD/DK7FuDlNo/pE8EcKMrfi2kqLRk8h8Gy/PDzgqJj64jNEzOce9pR8oj1w==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
+			"integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^24.5.0",
+				"@jest/types": "^24.8.0",
 				"babel-plugin-istanbul": "^5.1.0",
 				"chalk": "^2.0.1",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.1.15",
-				"jest-haste-map": "^24.5.0",
+				"jest-haste-map": "^24.8.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-util": "^24.5.0",
+				"jest-util": "^24.8.0",
 				"micromatch": "^3.1.10",
 				"realpath-native": "^1.1.0",
 				"slash": "^2.0.0",
@@ -2589,6 +5272,81 @@
 				"write-file-atomic": "2.4.1"
 			},
 			"dependencies": {
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
 				"@cnakazawa/watch": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -2600,20 +5358,20 @@
 					}
 				},
 				"babel-plugin-istanbul": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
-					"integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
+					"integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
 					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0",
-						"istanbul-lib-instrument": "^3.0.0",
-						"test-exclude": "^5.0.0"
+						"istanbul-lib-instrument": "^3.3.0",
+						"test-exclude": "^5.2.3"
 					}
 				},
 				"callsites": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-					"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 					"dev": true
 				},
 				"capture-exit": {
@@ -2652,6 +5410,554 @@
 						"strip-eof": "^1.0.0"
 					}
 				},
+				"fsevents": {
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+					"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"nan": "^2.12.1",
+						"node-pre-gyp": "^0.12.0"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"deep-extend": {
+							"version": "0.6.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.24",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": ">= 2.1.2 < 3"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minipass": {
+							"version": "2.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.2.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.3.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"debug": "^4.1.0",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.12.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.1",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.2.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.4.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.6.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"dev": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.7.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.3.4",
+								"minizlib": "^1.1.1",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2 || 2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"yallist": {
+							"version": "3.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
 				"get-stream": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -2677,41 +5983,44 @@
 					}
 				},
 				"istanbul-lib-coverage": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-					"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+					"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
 					"dev": true
 				},
 				"istanbul-lib-instrument": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
-					"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+					"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
 					"dev": true,
 					"requires": {
-						"@babel/generator": "^7.0.0",
-						"@babel/parser": "^7.0.0",
-						"@babel/template": "^7.0.0",
-						"@babel/traverse": "^7.0.0",
-						"@babel/types": "^7.0.0",
-						"istanbul-lib-coverage": "^2.0.3",
-						"semver": "^5.5.0"
+						"@babel/generator": "^7.4.0",
+						"@babel/parser": "^7.4.3",
+						"@babel/template": "^7.4.0",
+						"@babel/traverse": "^7.4.3",
+						"@babel/types": "^7.4.0",
+						"istanbul-lib-coverage": "^2.0.5",
+						"semver": "^6.0.0"
 					}
 				},
 				"jest-haste-map": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.5.0.tgz",
-					"integrity": "sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
+					"integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
+						"anymatch": "^2.0.0",
 						"fb-watchman": "^2.0.0",
+						"fsevents": "^1.2.7",
 						"graceful-fs": "^4.1.15",
 						"invariant": "^2.2.4",
 						"jest-serializer": "^24.4.0",
-						"jest-util": "^24.5.0",
-						"jest-worker": "^24.4.0",
+						"jest-util": "^24.8.0",
+						"jest-worker": "^24.6.0",
 						"micromatch": "^3.1.10",
-						"sane": "^4.0.3"
+						"sane": "^4.0.3",
+						"walker": "^1.0.7"
 					}
 				},
 				"jest-regex-util": {
@@ -2727,17 +6036,16 @@
 					"dev": true
 				},
 				"jest-util": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.5.0.tgz",
-					"integrity": "sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
+					"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
 					"dev": true,
 					"requires": {
-						"@jest/console": "^24.3.0",
-						"@jest/fake-timers": "^24.5.0",
+						"@jest/console": "^24.7.1",
+						"@jest/fake-timers": "^24.8.0",
 						"@jest/source-map": "^24.3.0",
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
-						"@types/node": "*",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"callsites": "^3.0.0",
 						"chalk": "^2.0.1",
 						"graceful-fs": "^4.1.15",
@@ -2748,12 +6056,11 @@
 					}
 				},
 				"jest-worker": {
-					"version": "24.4.0",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
-					"integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+					"integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
 					"dev": true,
 					"requires": {
-						"@types/node": "*",
 						"merge-stream": "^1.0.1",
 						"supports-color": "^6.1.0"
 					}
@@ -2775,6 +6082,13 @@
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
+				},
+				"nan": {
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+					"dev": true,
+					"optional": true
 				},
 				"path-type": {
 					"version": "3.0.0",
@@ -2812,6 +6126,12 @@
 						"read-pkg": "^3.0.0"
 					}
 				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
 				"rsvp": {
 					"version": "4.8.4",
 					"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
@@ -2834,6 +6154,12 @@
 						"minimist": "^1.1.1",
 						"walker": "~1.0.5"
 					}
+				},
+				"semver": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+					"dev": true
 				},
 				"slash": {
 					"version": "2.0.0",
@@ -2863,15 +6189,15 @@
 					}
 				},
 				"test-exclude": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
-					"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+					"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
 					"dev": true,
 					"requires": {
-						"arrify": "^1.0.1",
+						"glob": "^7.1.3",
 						"minimatch": "^3.0.4",
 						"read-pkg-up": "^4.0.0",
-						"require-main-filename": "^1.0.1"
+						"require-main-filename": "^2.0.0"
 					}
 				},
 				"write-file-atomic": {
@@ -2888,12 +6214,13 @@
 			}
 		},
 		"@jest/types": {
-			"version": "24.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.5.0.tgz",
-			"integrity": "sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==",
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
+			"integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
 			"dev": true,
 			"requires": {
-				"@types/istanbul-lib-coverage": "^1.1.0",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^1.1.1",
 				"@types/yargs": "^12.0.9"
 			}
 		},
@@ -3083,9 +6410,9 @@
 			"integrity": "sha512-Nggtk7/ljfNPpAX8CjxxLkMKuO6u2gH1ozmTvGclWF2pNcxTf6YGghYNYNWZRKrimXGhQ8yZqvAHep7h80K04g=="
 		},
 		"@types/babel__core": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.0.tgz",
-			"integrity": "sha512-wJTeJRt7BToFx3USrCDs2BhEi4ijBInTQjOIukj6a/5tEkwpFMVZ+1ppgmE+Q/FQyc5P/VWUbx7I9NELrKruHA==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
+			"integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -3141,10 +6468,29 @@
 			}
 		},
 		"@types/istanbul-lib-coverage": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-			"integrity": "sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+			"integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
 			"dev": true
+		},
+		"@types/istanbul-lib-report": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+			"integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"@types/istanbul-reports": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+			"integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "*",
+				"@types/istanbul-lib-report": "*"
+			}
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -3204,9 +6550,9 @@
 			}
 		},
 		"@types/yargs": {
-			"version": "12.0.9",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.9.tgz",
-			"integrity": "sha512-sCZy4SxP9rN2w30Hlmg5dtdRwgYQfYRiLo9usw8X9cxlf+H4FqM1xX7+sNH7NNKVdbXMJWqva7iyy+fxh/V7fA==",
+			"version": "12.0.12",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
+			"integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
@@ -3491,32 +6837,544 @@
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.0.0.tgz",
-			"integrity": "sha512-aBeW3yaJze+e+dB+Tfs1lA9zGiPAOQ2mt0FbvpNB2Bskq9WoXWrZknV4c4SzqYBTkvTnsB38dtf91bTbsvIcnQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.2.0.tgz",
+			"integrity": "sha512-H31qqjbXrQebue4ho8bu/vCPkVCENalxQMMAQOGulmQxOQ6IF+9uwglCR6ZiAWhZmPo6LFq0NQ+IPLSUX8IS8Q==",
 			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.0.0.tgz",
-			"integrity": "sha512-ksNXl8iq4n08zjed3Na/MQxYuUXOSl4JlnBHEBNIgclIUEzsFf0ixKCxaCASBCU8kgpvZHHdLBECxvL8G12jDg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.2.0.tgz",
+			"integrity": "sha512-a0+PzFKRgmZLILdkCwTqoEJY3getFRqiT1mtd1hQvszrX01RbKmeOmPHx6OZPE0HhbYWS4HK/RCGXgBfPy7ROw==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.2.2",
+				"@babel/core": "^7.4.4",
 				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.3.2",
+				"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
 				"@babel/plugin-transform-react-jsx": "^7.3.0",
-				"@babel/plugin-transform-runtime": "^7.2.0",
-				"@babel/preset-env": "^7.3.1",
-				"@babel/runtime": "^7.3.1",
-				"@wordpress/babel-plugin-import-jsx-pragma": "^2.0.0",
-				"@wordpress/browserslist-config": "^2.3.0"
+				"@babel/plugin-transform-runtime": "^7.4.4",
+				"@babel/preset-env": "^7.4.4",
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/babel-plugin-import-jsx-pragma": "^2.2.0",
+				"@wordpress/browserslist-config": "^2.4.0"
+			},
+			"dependencies": {
+				"@babel/core": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
+					"integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helpers": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/template": "^7.4.4",
+						"@babel/traverse": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"convert-source-map": "^1.1.0",
+						"debug": "^4.1.0",
+						"json5": "^2.1.0",
+						"lodash": "^4.17.11",
+						"resolve": "^1.3.2",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-call-delegate": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+					"integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.4.4",
+						"@babel/traverse": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/helper-define-map": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
+					"integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/types": "^7.4.4",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+					"integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+					"integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-simple-access": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/template": "^7.4.4",
+						"@babel/types": "^7.4.4",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/helper-regex": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
+					"integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
+					"integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.0.0",
+						"@babel/helper-optimise-call-expression": "^7.0.0",
+						"@babel/traverse": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/helpers": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+					"integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.4.4",
+						"@babel/traverse": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
+					"integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+					}
+				},
+				"@babel/plugin-proposal-unicode-property-regex": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+					"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-regex": "^7.4.4",
+						"regexpu-core": "^4.5.4"
+					}
+				},
+				"@babel/plugin-transform-async-to-generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
+					"integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-remap-async-to-generator": "^7.1.0"
+					}
+				},
+				"@babel/plugin-transform-block-scoping": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
+					"integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/plugin-transform-classes": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
+					"integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.0.0",
+						"@babel/helper-define-map": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-optimise-call-expression": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.4.4",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
+					"integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-dotall-regex": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+					"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-regex": "^7.4.4",
+						"regexpu-core": "^4.5.4"
+					}
+				},
+				"@babel/plugin-transform-for-of": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+					"integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-function-name": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+					"integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-modules-commonjs": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
+					"integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.4.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-simple-access": "^7.1.0"
+					}
+				},
+				"@babel/plugin-transform-modules-systemjs": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
+					"integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.4.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-named-capturing-groups-regex": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
+					"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+					"dev": true,
+					"requires": {
+						"regexp-tree": "^0.1.6"
+					}
+				},
+				"@babel/plugin-transform-new-target": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+					"integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-parameters": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+					"integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-call-delegate": "^7.4.4",
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-regenerator": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+					"integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+					"dev": true,
+					"requires": {
+						"regenerator-transform": "^0.14.0"
+					}
+				},
+				"@babel/plugin-transform-runtime": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz",
+					"integrity": "sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"resolve": "^1.8.1",
+						"semver": "^5.5.1"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+							"dev": true
+						}
+					}
+				},
+				"@babel/plugin-transform-template-literals": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+					"integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-unicode-regex": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+					"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-regex": "^7.4.4",
+						"regexpu-core": "^4.5.4"
+					}
+				},
+				"@babel/preset-env": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.5.tgz",
+					"integrity": "sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+						"@babel/plugin-proposal-json-strings": "^7.2.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+						"@babel/plugin-syntax-async-generators": "^7.2.0",
+						"@babel/plugin-syntax-json-strings": "^7.2.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+						"@babel/plugin-transform-arrow-functions": "^7.2.0",
+						"@babel/plugin-transform-async-to-generator": "^7.4.4",
+						"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+						"@babel/plugin-transform-block-scoping": "^7.4.4",
+						"@babel/plugin-transform-classes": "^7.4.4",
+						"@babel/plugin-transform-computed-properties": "^7.2.0",
+						"@babel/plugin-transform-destructuring": "^7.4.4",
+						"@babel/plugin-transform-dotall-regex": "^7.4.4",
+						"@babel/plugin-transform-duplicate-keys": "^7.2.0",
+						"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+						"@babel/plugin-transform-for-of": "^7.4.4",
+						"@babel/plugin-transform-function-name": "^7.4.4",
+						"@babel/plugin-transform-literals": "^7.2.0",
+						"@babel/plugin-transform-member-expression-literals": "^7.2.0",
+						"@babel/plugin-transform-modules-amd": "^7.2.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.4.4",
+						"@babel/plugin-transform-modules-systemjs": "^7.4.4",
+						"@babel/plugin-transform-modules-umd": "^7.2.0",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+						"@babel/plugin-transform-new-target": "^7.4.4",
+						"@babel/plugin-transform-object-super": "^7.2.0",
+						"@babel/plugin-transform-parameters": "^7.4.4",
+						"@babel/plugin-transform-property-literals": "^7.2.0",
+						"@babel/plugin-transform-regenerator": "^7.4.5",
+						"@babel/plugin-transform-reserved-words": "^7.2.0",
+						"@babel/plugin-transform-shorthand-properties": "^7.2.0",
+						"@babel/plugin-transform-spread": "^7.2.0",
+						"@babel/plugin-transform-sticky-regex": "^7.2.0",
+						"@babel/plugin-transform-template-literals": "^7.4.4",
+						"@babel/plugin-transform-typeof-symbol": "^7.2.0",
+						"@babel/plugin-transform-unicode-regex": "^7.4.4",
+						"@babel/types": "^7.4.4",
+						"browserslist": "^4.6.0",
+						"core-js-compat": "^3.1.1",
+						"invariant": "^2.2.2",
+						"js-levenshtein": "^1.1.3",
+						"semver": "^5.5.0"
+					}
+				},
+				"@babel/runtime": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+					"integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"browserslist": {
+					"version": "4.6.1",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
+					"integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000971",
+						"electron-to-chromium": "^1.3.137",
+						"node-releases": "^1.1.21"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000973",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000973.tgz",
+					"integrity": "sha512-/F3t/Yo8LEdRSEPCmI15fLu5vepVh9UCg/9inJXF5AAfW7xRRJkbaM2ut52iRMQMnGCLQouLbFdbOA+VEFOIsg==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.147",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.147.tgz",
+					"integrity": "sha512-pHE+9S2OMXOLAze6KvKMA9Te56M5e4WIdPPPeZ2JiSNvpXkDrn9FoBot1yeeXMRClWvQGI6vj06kQFqCADrspQ==",
+					"dev": true
+				},
+				"node-releases": {
+					"version": "1.1.23",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz",
+					"integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
+					"dev": true,
+					"requires": {
+						"semver": "^5.3.0"
+					}
+				},
+				"regenerate-unicode-properties": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+					"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.2",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+					"dev": true
+				},
+				"regenerator-transform": {
+					"version": "0.14.0",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
+					"integrity": "sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==",
+					"dev": true,
+					"requires": {
+						"private": "^0.1.6"
+					}
+				},
+				"regexp-tree": {
+					"version": "0.1.10",
+					"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.10.tgz",
+					"integrity": "sha512-K1qVSbcedffwuIslMwpe6vGlj+ZXRnGkvjAtFHfDZZZuEdA/h0dxljAPu9vhUo6Rrx2U2AwJ+nSQ6hK+lrP5MQ==",
+					"dev": true
+				},
+				"regexpu-core": {
+					"version": "4.5.4",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+					"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.0.2",
+						"regjsgen": "^0.5.0",
+						"regjsparser": "^0.6.0",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.1.0"
+					}
+				},
+				"unicode-match-property-value-ecmascript": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+					"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/browserslist-config": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.3.0.tgz",
-			"integrity": "sha512-bNOahe6ntNF3pRvCaeh2tGgnpPxe35U6UBfvRjDcOk3sIRvN1S7XlG0rlGZOOD+vJU93VLDM8AUj4uL6VPqPgQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.4.0.tgz",
+			"integrity": "sha512-d2OmEK/qsZQxTQ449M0eatFYlW/en/ISQtakSDkaY0YB2FKZN2cM5rgOcV1aHQdkrAW00nVorMo4BPH7TpgH6g==",
 			"dev": true
 		},
 		"@wordpress/components": {
@@ -3591,6 +7449,16 @@
 				"turbo-combine-reducers": "^1.0.2"
 			}
 		},
+		"@wordpress/dependency-extraction-webpack-plugin": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.0.1.tgz",
+			"integrity": "sha512-Ov4IljSGSPDjQPKV79tXKk7Ljndo+f84aImKIH8mzTMRbZS+7wPzz6jHAa/FpGmf7R99QqaN4CNRpvBihu3o9Q==",
+			"dev": true,
+			"requires": {
+				"webpack": "^4.8.3",
+				"webpack-sources": "^1.3.0"
+			}
+		},
 		"@wordpress/dom": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.1.0.tgz",
@@ -3629,229 +7497,47 @@
 			}
 		},
 		"@wordpress/eslint-plugin": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-2.0.0.tgz",
-			"integrity": "sha512-xfCnwpUhci1MkSpxZBF/imiJ7OnRix8DpqiVxGFevqOcnWw65f8Mzj0rFSQvClQnn5ZZWFz5pzNnKNs+UrImrg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-2.2.0.tgz",
+			"integrity": "sha512-0NhyA+sMaLOzdNNhzTIXamllTqcBC6VRQlkkeroJUs8XkTzbCb+xCKuYWQARamjIGBmIo5ljXyKevYYj+VQqyA==",
 			"dev": true,
 			"requires": {
-				"babel-eslint": "^8.0.3",
-				"eslint-plugin-jsx-a11y": "6.0.2",
-				"eslint-plugin-react": "7.7.0",
+				"babel-eslint": "^10.0.1",
+				"eslint-plugin-jsx-a11y": "^6.2.1",
+				"eslint-plugin-react": "^7.12.4",
+				"eslint-plugin-react-hooks": "^1.6.0",
 				"requireindex": "^1.2.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-					"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.44"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-					"integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.44",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.2.0",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-					"integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.44",
-						"@babel/template": "7.0.0-beta.44",
-						"@babel/types": "7.0.0-beta.44"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-					"integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.44"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-					"integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.44"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-					"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/template": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-					"integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.44",
-						"@babel/types": "7.0.0-beta.44",
-						"babylon": "7.0.0-beta.44",
-						"lodash": "^4.2.0"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-					"integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.44",
-						"@babel/generator": "7.0.0-beta.44",
-						"@babel/helper-function-name": "7.0.0-beta.44",
-						"@babel/helper-split-export-declaration": "7.0.0-beta.44",
-						"@babel/types": "7.0.0-beta.44",
-						"babylon": "7.0.0-beta.44",
-						"debug": "^3.1.0",
-						"globals": "^11.1.0",
-						"invariant": "^2.2.0",
-						"lodash": "^4.2.0"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-					"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.2.0",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"aria-query": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.1.tgz",
-					"integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
-					"dev": true,
-					"requires": {
-						"ast-types-flow": "0.0.7",
-						"commander": "^2.11.0"
-					}
-				},
-				"axobject-query": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
-					"integrity": "sha1-YvWdvFnJ+SQnWco0mWDnov48NsA=",
-					"dev": true,
-					"requires": {
-						"ast-types-flow": "0.0.7"
-					}
-				},
 				"babel-eslint": {
-					"version": "8.2.6",
-					"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
-					"integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+					"version": "10.0.1",
+					"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
+					"integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "7.0.0-beta.44",
-						"@babel/traverse": "7.0.0-beta.44",
-						"@babel/types": "7.0.0-beta.44",
-						"babylon": "7.0.0-beta.44",
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.0.0",
+						"@babel/traverse": "^7.0.0",
+						"@babel/types": "^7.0.0",
 						"eslint-scope": "3.7.1",
 						"eslint-visitor-keys": "^1.0.0"
 					}
 				},
-				"babylon": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-					"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-					"dev": true
-				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"emoji-regex": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-					"integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
-					"dev": true
-				},
 				"eslint-plugin-jsx-a11y": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.2.tgz",
-					"integrity": "sha1-ZZJ3p1iwNsMFp+ShMFfDAc075z8=",
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+					"integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
 					"dev": true,
 					"requires": {
-						"aria-query": "^0.7.0",
+						"aria-query": "^3.0.0",
 						"array-includes": "^3.0.3",
-						"ast-types-flow": "0.0.7",
-						"axobject-query": "^0.1.0",
-						"damerau-levenshtein": "^1.0.0",
-						"emoji-regex": "^6.1.0",
-						"jsx-ast-utils": "^1.4.0"
+						"ast-types-flow": "^0.0.7",
+						"axobject-query": "^2.0.2",
+						"damerau-levenshtein": "^1.0.4",
+						"emoji-regex": "^7.0.2",
+						"has": "^1.0.3",
+						"jsx-ast-utils": "^2.0.1"
 					}
-				},
-				"eslint-plugin-react": {
-					"version": "7.7.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
-					"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
-					"dev": true,
-					"requires": {
-						"doctrine": "^2.0.2",
-						"has": "^1.0.1",
-						"jsx-ast-utils": "^2.0.1",
-						"prop-types": "^15.6.0"
-					},
-					"dependencies": {
-						"jsx-ast-utils": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-							"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
-							"dev": true,
-							"requires": {
-								"array-includes": "^3.0.3"
-							}
-						}
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				},
-				"jsx-ast-utils": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-					"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
-					"dev": true
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
 				}
 			}
 		},
@@ -3892,16 +7578,25 @@
 			}
 		},
 		"@wordpress/jest-console": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-3.0.0.tgz",
-			"integrity": "sha512-HLrAipHVEdbC9yMYLWV/ErjhripymZkKkIePhzdBj+RiARUqXIkeD12wZX8Sq295j4KBShs4d3I5vNdxvQ+ZAw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-3.1.0.tgz",
+			"integrity": "sha512-6ofKMrGnmDFUnc9zdxN8AfuD3IDrf4THnvJ2QEvz71FVZZbFRLlFZOGs4O/IFmPPOMa/0/lGvTEJr9THZ44wBw==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.3.1",
-				"jest-matcher-utils": "^24.0.0",
+				"@babel/runtime": "^7.4.4",
+				"jest-matcher-utils": "^24.7.0",
 				"lodash": "^4.17.11"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+					"integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -3909,105 +7604,178 @@
 					"dev": true
 				},
 				"jest-diff": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.5.0.tgz",
-					"integrity": "sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
+					"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"diff-sequences": "^24.3.0",
-						"jest-get-type": "^24.3.0",
-						"pretty-format": "^24.5.0"
+						"jest-get-type": "^24.8.0",
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-get-type": {
-					"version": "24.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
-					"integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+					"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
 					"dev": true
 				},
 				"jest-matcher-utils": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz",
-					"integrity": "sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+					"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
-						"jest-diff": "^24.5.0",
-						"jest-get-type": "^24.3.0",
-						"pretty-format": "^24.5.0"
+						"jest-diff": "^24.8.0",
+						"jest-get-type": "^24.8.0",
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"pretty-format": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
-					"integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+					"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"ansi-regex": "^4.0.0",
 						"ansi-styles": "^3.2.0",
 						"react-is": "^16.8.4"
 					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.2",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+					"dev": true
 				}
 			}
 		},
 		"@wordpress/jest-preset-default": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-4.0.0.tgz",
-			"integrity": "sha512-26F8+ZKajgrL59o02Tes7roEvaM0mEl1AuCUUPF67/EOL5aIsKQNnSPd4JFAPJ8jjuthXBpYW+duCx5g4UYcHQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-4.1.0.tgz",
+			"integrity": "sha512-eGV1UwfKiHNpqw78YbxXIpe0ia99Rd9Hn5IqnSJJGtQ6ObhenJC4iVKEtAPvvranHajkZGxMGvhvvH0B9KYm0Q==",
 			"dev": true,
 			"requires": {
-				"@wordpress/jest-console": "^3.0.0",
-				"babel-jest": "^24.1.0",
+				"@wordpress/jest-console": "^3.1.0",
+				"babel-jest": "^24.7.1",
 				"enzyme": "^3.9.0",
 				"enzyme-adapter-react-16": "^1.10.0",
 				"enzyme-to-json": "^3.3.5"
 			},
 			"dependencies": {
-				"babel-jest": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.5.0.tgz",
-					"integrity": "sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==",
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
 					"dev": true,
 					"requires": {
-						"@jest/transform": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"babel-jest": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
+					"integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
+					"dev": true,
+					"requires": {
+						"@jest/transform": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"@types/babel__core": "^7.1.0",
 						"babel-plugin-istanbul": "^5.1.0",
-						"babel-preset-jest": "^24.3.0",
+						"babel-preset-jest": "^24.6.0",
 						"chalk": "^2.4.2",
 						"slash": "^2.0.0"
 					}
 				},
 				"babel-plugin-istanbul": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
-					"integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
+					"integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
 					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0",
-						"istanbul-lib-instrument": "^3.0.0",
-						"test-exclude": "^5.0.0"
+						"istanbul-lib-instrument": "^3.3.0",
+						"test-exclude": "^5.2.3"
 					}
 				},
 				"babel-plugin-jest-hoist": {
-					"version": "24.3.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz",
-					"integrity": "sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==",
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+					"integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
 					"dev": true,
 					"requires": {
 						"@types/babel__traverse": "^7.0.6"
 					}
 				},
 				"babel-preset-jest": {
-					"version": "24.3.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz",
-					"integrity": "sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==",
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+					"integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
 					"dev": true,
 					"requires": {
 						"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-						"babel-plugin-jest-hoist": "^24.3.0"
+						"babel-plugin-jest-hoist": "^24.6.0"
 					}
 				},
 				"chalk": {
@@ -4022,24 +7790,24 @@
 					}
 				},
 				"istanbul-lib-coverage": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-					"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+					"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
 					"dev": true
 				},
 				"istanbul-lib-instrument": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
-					"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+					"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
 					"dev": true,
 					"requires": {
-						"@babel/generator": "^7.0.0",
-						"@babel/parser": "^7.0.0",
-						"@babel/template": "^7.0.0",
-						"@babel/traverse": "^7.0.0",
-						"@babel/types": "^7.0.0",
-						"istanbul-lib-coverage": "^2.0.3",
-						"semver": "^5.5.0"
+						"@babel/generator": "^7.4.0",
+						"@babel/parser": "^7.4.3",
+						"@babel/template": "^7.4.0",
+						"@babel/traverse": "^7.4.3",
+						"@babel/types": "^7.4.0",
+						"istanbul-lib-coverage": "^2.0.5",
+						"semver": "^6.0.0"
 					}
 				},
 				"load-json-file": {
@@ -4090,6 +7858,18 @@
 						"read-pkg": "^3.0.0"
 					}
 				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+					"dev": true
+				},
 				"slash": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -4112,15 +7892,15 @@
 					}
 				},
 				"test-exclude": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
-					"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+					"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
 					"dev": true,
 					"requires": {
-						"arrify": "^1.0.1",
+						"glob": "^7.1.3",
 						"minimatch": "^3.0.4",
 						"read-pkg-up": "^4.0.0",
-						"require-main-filename": "^1.0.1"
+						"require-main-filename": "^2.0.0"
 					}
 				}
 			}
@@ -4136,9 +7916,9 @@
 			}
 		},
 		"@wordpress/npm-package-json-lint-config": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-1.2.0.tgz",
-			"integrity": "sha512-7btuRn18RUALwi1ExoTaRHdb4YZEqfTRWge8FTpZAZtppV338upwJ65mAg3MfaJh0XzcW8XVVlEXBuARGyXtyg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-1.3.0.tgz",
+			"integrity": "sha512-3BlWs7FJms0AOu8vsm2VEmNcIM+tlSgich0AaDPPn/nY0j2knJNNGupDUA9/vmYssvufI/uCTJRq84FHQCOmGA==",
 			"dev": true
 		},
 		"@wordpress/priority-queue": {
@@ -4173,21 +7953,22 @@
 			}
 		},
 		"@wordpress/scripts": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-3.0.0.tgz",
-			"integrity": "sha512-d8pDcRQ7ywuZ7xHpRwezdBWM+MmvwIfKwPrnHdWbTeknkazUJeFYVQjlueKRsCdk7qem8rtHep97YGqTivKvqw==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-3.2.1.tgz",
+			"integrity": "sha512-GrOTew6JcRKTTfy/512Wc/dX2xcTQccw04OPJHjfMmp1zU1V/Y1SODSdD5KacygYnBza1NKher6QBP6wKyBF8w==",
 			"dev": true,
 			"requires": {
-				"@wordpress/babel-preset-default": "^4.0.0",
-				"@wordpress/eslint-plugin": "^2.0.0",
-				"@wordpress/jest-preset-default": "^4.0.0",
-				"@wordpress/npm-package-json-lint-config": "^1.2.0",
+				"@wordpress/babel-preset-default": "^4.2.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^1.0.1",
+				"@wordpress/eslint-plugin": "^2.2.0",
+				"@wordpress/jest-preset-default": "^4.1.0",
+				"@wordpress/npm-package-json-lint-config": "^1.3.0",
 				"babel-loader": "^8.0.5",
 				"chalk": "^2.4.1",
 				"check-node-version": "^3.1.1",
 				"cross-spawn": "^5.1.0",
-				"eslint": "^5.12.1",
-				"jest": "^24.1.0",
+				"eslint": "^5.16.0",
+				"jest": "^24.7.1",
 				"jest-puppeteer": "^4.0.0",
 				"npm-package-json-lint": "^3.6.0",
 				"puppeteer": "1.6.1",
@@ -4196,12 +7977,80 @@
 				"source-map-loader": "^0.2.4",
 				"stylelint": "^9.10.1",
 				"stylelint-config-wordpress": "^13.1.0",
+				"thread-loader": "^2.1.2",
 				"webpack": "4.8.3",
 				"webpack-bundle-analyzer": "^3.0.3",
 				"webpack-cli": "^3.1.2",
 				"webpack-livereload-plugin": "^2.2.0"
 			},
 			"dependencies": {
+				"@babel/generator": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+					"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+					"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+					"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+					"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
 				"@cnakazawa/watch": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -4441,16 +8290,16 @@
 					"dev": true
 				},
 				"babel-jest": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.5.0.tgz",
-					"integrity": "sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
+					"integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
 					"dev": true,
 					"requires": {
-						"@jest/transform": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/transform": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"@types/babel__core": "^7.1.0",
 						"babel-plugin-istanbul": "^5.1.0",
-						"babel-preset-jest": "^24.3.0",
+						"babel-preset-jest": "^24.6.0",
 						"chalk": "^2.4.2",
 						"slash": "^2.0.0"
 					},
@@ -4469,45 +8318,45 @@
 					}
 				},
 				"babel-plugin-istanbul": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
-					"integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
+					"integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
 					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0",
-						"istanbul-lib-instrument": "^3.0.0",
-						"test-exclude": "^5.0.0"
+						"istanbul-lib-instrument": "^3.3.0",
+						"test-exclude": "^5.2.3"
 					}
 				},
 				"babel-plugin-jest-hoist": {
-					"version": "24.3.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz",
-					"integrity": "sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==",
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+					"integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
 					"dev": true,
 					"requires": {
 						"@types/babel__traverse": "^7.0.6"
 					}
 				},
 				"babel-preset-jest": {
-					"version": "24.3.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz",
-					"integrity": "sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==",
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+					"integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
 					"dev": true,
 					"requires": {
 						"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-						"babel-plugin-jest-hoist": "^24.3.0"
+						"babel-plugin-jest-hoist": "^24.6.0"
 					}
 				},
 				"callsites": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-					"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 					"dev": true
 				},
 				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
 				"capture-exit": {
@@ -4552,9 +8401,9 @@
 					}
 				},
 				"eslint": {
-					"version": "5.15.2",
-					"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.2.tgz",
-					"integrity": "sha512-I8VM4SILpMwUvsRt83bQVwIRQAJ2iPMXun1FVZ/lV1OHklH2tJaXqoDnNzdiFc6bnCtGKXvQIQNP3kj1eMskSw==",
+					"version": "5.16.0",
+					"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+					"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
@@ -4577,7 +8426,7 @@
 						"import-fresh": "^3.0.0",
 						"imurmurhash": "^0.1.4",
 						"inquirer": "^6.2.2",
-						"js-yaml": "^3.12.0",
+						"js-yaml": "^3.13.0",
 						"json-stable-stringify-without-jsonify": "^1.0.1",
 						"levn": "^0.3.0",
 						"lodash": "^4.17.11",
@@ -4657,16 +8506,16 @@
 					}
 				},
 				"expect": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/expect/-/expect-24.5.0.tgz",
-					"integrity": "sha512-p2Gmc0CLxOgkyA93ySWmHFYHUPFIHG6XZ06l7WArWAsrqYVaVEkOU5NtT5i68KUyGKbkQgDCkiT65bWmdoL6Bw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
+					"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"ansi-styles": "^3.2.0",
-						"jest-get-type": "^24.3.0",
-						"jest-matcher-utils": "^24.5.0",
-						"jest-message-util": "^24.5.0",
+						"jest-get-type": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
 						"jest-regex-util": "^24.3.0"
 					}
 				},
@@ -4694,6 +8543,554 @@
 						"flatted": "^2.0.0",
 						"rimraf": "2.6.3",
 						"write": "1.0.3"
+					}
+				},
+				"fsevents": {
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+					"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"nan": "^2.12.1",
+						"node-pre-gyp": "^0.12.0"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"deep-extend": {
+							"version": "0.6.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.24",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": ">= 2.1.2 < 3"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minipass": {
+							"version": "2.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.2.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.3.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"debug": "^4.1.0",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.12.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.1",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.2.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.4.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.6.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"dev": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.7.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.3.4",
+								"minizlib": "^1.1.1",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2 || 2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"yallist": {
+							"version": "3.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
 					}
 				},
 				"get-stream": {
@@ -4735,58 +9132,66 @@
 					}
 				},
 				"is-generator-fn": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
-					"integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+					"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 					"dev": true
 				},
 				"istanbul-lib-coverage": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-					"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+					"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
 					"dev": true
 				},
 				"istanbul-lib-instrument": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
-					"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+					"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
 					"dev": true,
 					"requires": {
-						"@babel/generator": "^7.0.0",
-						"@babel/parser": "^7.0.0",
-						"@babel/template": "^7.0.0",
-						"@babel/traverse": "^7.0.0",
-						"@babel/types": "^7.0.0",
-						"istanbul-lib-coverage": "^2.0.3",
-						"semver": "^5.5.0"
+						"@babel/generator": "^7.4.0",
+						"@babel/parser": "^7.4.3",
+						"@babel/template": "^7.4.0",
+						"@babel/traverse": "^7.4.3",
+						"@babel/types": "^7.4.0",
+						"istanbul-lib-coverage": "^2.0.5",
+						"semver": "^6.0.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "6.1.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+							"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+							"dev": true
+						}
 					}
 				},
 				"jest": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest/-/jest-24.5.0.tgz",
-					"integrity": "sha512-lxL+Fq5/RH7inxxmfS2aZLCf8MsS+YCUBfeiNO6BWz/MmjhDGaIEA/2bzEf9q4Q0X+mtFHiinHFvQ0u+RvW/qQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",
+					"integrity": "sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==",
 					"dev": true,
 					"requires": {
 						"import-local": "^2.0.0",
-						"jest-cli": "^24.5.0"
+						"jest-cli": "^24.8.0"
 					},
 					"dependencies": {
 						"jest-cli": {
-							"version": "24.5.0",
-							"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.5.0.tgz",
-							"integrity": "sha512-P+Jp0SLO4KWN0cGlNtC7JV0dW1eSFR7eRpoOucP2UM0sqlzp/bVHeo71Omonvigrj9AvCKy7NtQANtqJ7FXz8g==",
+							"version": "24.8.0",
+							"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.8.0.tgz",
+							"integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
 							"dev": true,
 							"requires": {
-								"@jest/core": "^24.5.0",
-								"@jest/test-result": "^24.5.0",
-								"@jest/types": "^24.5.0",
+								"@jest/core": "^24.8.0",
+								"@jest/test-result": "^24.8.0",
+								"@jest/types": "^24.8.0",
 								"chalk": "^2.0.1",
 								"exit": "^0.1.2",
 								"import-local": "^2.0.0",
 								"is-ci": "^2.0.0",
-								"jest-config": "^24.5.0",
-								"jest-util": "^24.5.0",
-								"jest-validate": "^24.5.0",
+								"jest-config": "^24.8.0",
+								"jest-util": "^24.8.0",
+								"jest-validate": "^24.8.0",
 								"prompts": "^2.0.1",
 								"realpath-native": "^1.1.0",
 								"yargs": "^12.0.2"
@@ -4795,102 +9200,106 @@
 					}
 				},
 				"jest-config": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.5.0.tgz",
-					"integrity": "sha512-t2UTh0Z2uZhGBNVseF8wA2DS2SuBiLOL6qpLq18+OZGfFUxTM7BzUVKyHFN/vuN+s/aslY1COW95j1Rw81huOQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
+					"integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
 					"dev": true,
 					"requires": {
 						"@babel/core": "^7.1.0",
-						"@jest/types": "^24.5.0",
-						"babel-jest": "^24.5.0",
+						"@jest/test-sequencer": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"babel-jest": "^24.8.0",
 						"chalk": "^2.0.1",
 						"glob": "^7.1.1",
-						"jest-environment-jsdom": "^24.5.0",
-						"jest-environment-node": "^24.5.0",
-						"jest-get-type": "^24.3.0",
-						"jest-jasmine2": "^24.5.0",
+						"jest-environment-jsdom": "^24.8.0",
+						"jest-environment-node": "^24.8.0",
+						"jest-get-type": "^24.8.0",
+						"jest-jasmine2": "^24.8.0",
 						"jest-regex-util": "^24.3.0",
-						"jest-resolve": "^24.5.0",
-						"jest-util": "^24.5.0",
-						"jest-validate": "^24.5.0",
+						"jest-resolve": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-validate": "^24.8.0",
 						"micromatch": "^3.1.10",
-						"pretty-format": "^24.5.0",
+						"pretty-format": "^24.8.0",
 						"realpath-native": "^1.1.0"
 					}
 				},
 				"jest-diff": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.5.0.tgz",
-					"integrity": "sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
+					"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"diff-sequences": "^24.3.0",
-						"jest-get-type": "^24.3.0",
-						"pretty-format": "^24.5.0"
+						"jest-get-type": "^24.8.0",
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-each": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.5.0.tgz",
-					"integrity": "sha512-6gy3Kh37PwIT5sNvNY2VchtIFOOBh8UCYnBlxXMb5sr5wpJUDPTUATX2Axq1Vfk+HWTMpsYPeVYp4TXx5uqUBw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
+					"integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"chalk": "^2.0.1",
-						"jest-get-type": "^24.3.0",
-						"jest-util": "^24.5.0",
-						"pretty-format": "^24.5.0"
+						"jest-get-type": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-environment-jsdom": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.5.0.tgz",
-					"integrity": "sha512-62Ih5HbdAWcsqBx2ktUnor/mABBo1U111AvZWcLKeWN/n/gc5ZvDBKe4Og44fQdHKiXClrNGC6G0mBo6wrPeGQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
+					"integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
 					"dev": true,
 					"requires": {
-						"@jest/environment": "^24.5.0",
-						"@jest/fake-timers": "^24.5.0",
-						"@jest/types": "^24.5.0",
-						"jest-mock": "^24.5.0",
-						"jest-util": "^24.5.0",
+						"@jest/environment": "^24.8.0",
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"jest-mock": "^24.8.0",
+						"jest-util": "^24.8.0",
 						"jsdom": "^11.5.1"
 					}
 				},
 				"jest-environment-node": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.5.0.tgz",
-					"integrity": "sha512-du6FuyWr/GbKLsmAbzNF9mpr2Iu2zWSaq/BNHzX+vgOcts9f2ayXBweS7RAhr+6bLp6qRpMB6utAMF5Ygktxnw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
+					"integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
 					"dev": true,
 					"requires": {
-						"@jest/environment": "^24.5.0",
-						"@jest/fake-timers": "^24.5.0",
-						"@jest/types": "^24.5.0",
-						"jest-mock": "^24.5.0",
-						"jest-util": "^24.5.0"
+						"@jest/environment": "^24.8.0",
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"jest-mock": "^24.8.0",
+						"jest-util": "^24.8.0"
 					}
 				},
 				"jest-get-type": {
-					"version": "24.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
-					"integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+					"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
 					"dev": true
 				},
 				"jest-haste-map": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.5.0.tgz",
-					"integrity": "sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
+					"integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
+						"anymatch": "^2.0.0",
 						"fb-watchman": "^2.0.0",
+						"fsevents": "^1.2.7",
 						"graceful-fs": "^4.1.15",
 						"invariant": "^2.2.4",
 						"jest-serializer": "^24.4.0",
-						"jest-util": "^24.5.0",
-						"jest-worker": "^24.4.0",
+						"jest-util": "^24.8.0",
+						"jest-worker": "^24.6.0",
 						"micromatch": "^3.1.10",
-						"sane": "^4.0.3"
+						"sane": "^4.0.3",
+						"walker": "^1.0.7"
 					},
 					"dependencies": {
 						"graceful-fs": {
@@ -4902,50 +9311,50 @@
 					}
 				},
 				"jest-jasmine2": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.5.0.tgz",
-					"integrity": "sha512-sfVrxVcx1rNUbBeyIyhkqZ4q+seNKyAG6iM0S2TYBdQsXjoFDdqWFfsUxb6uXSsbimbXX/NMkJIwUZ1uT9+/Aw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
+					"integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
 					"dev": true,
 					"requires": {
 						"@babel/traverse": "^7.1.0",
-						"@jest/environment": "^24.5.0",
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/environment": "^24.8.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"chalk": "^2.0.1",
 						"co": "^4.6.0",
-						"expect": "^24.5.0",
+						"expect": "^24.8.0",
 						"is-generator-fn": "^2.0.0",
-						"jest-each": "^24.5.0",
-						"jest-matcher-utils": "^24.5.0",
-						"jest-message-util": "^24.5.0",
-						"jest-runtime": "^24.5.0",
-						"jest-snapshot": "^24.5.0",
-						"jest-util": "^24.5.0",
-						"pretty-format": "^24.5.0",
+						"jest-each": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-runtime": "^24.8.0",
+						"jest-snapshot": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"pretty-format": "^24.8.0",
 						"throat": "^4.0.0"
 					}
 				},
 				"jest-matcher-utils": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz",
-					"integrity": "sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+					"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
-						"jest-diff": "^24.5.0",
-						"jest-get-type": "^24.3.0",
-						"pretty-format": "^24.5.0"
+						"jest-diff": "^24.8.0",
+						"jest-get-type": "^24.8.0",
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-message-util": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.5.0.tgz",
-					"integrity": "sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
+					"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"@types/stack-utils": "^1.0.1",
 						"chalk": "^2.0.1",
 						"micromatch": "^3.1.10",
@@ -4954,12 +9363,12 @@
 					}
 				},
 				"jest-mock": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.5.0.tgz",
-					"integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
+					"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0"
+						"@jest/types": "^24.8.0"
 					}
 				},
 				"jest-pnp-resolver": {
@@ -4975,12 +9384,12 @@
 					"dev": true
 				},
 				"jest-resolve": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.5.0.tgz",
-					"integrity": "sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+					"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"browser-resolve": "^1.11.3",
 						"chalk": "^2.0.1",
 						"jest-pnp-resolver": "^1.2.1",
@@ -4988,30 +9397,30 @@
 					}
 				},
 				"jest-runtime": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.5.0.tgz",
-					"integrity": "sha512-GTFHzfLdwpaeoDPilNpBrorlPoNZuZrwKKzKJs09vWwHo+9TOsIIuszK8cWOuKC7ss07aN1922Ge8fsGdsqCuw==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
+					"integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
 					"dev": true,
 					"requires": {
-						"@jest/console": "^24.3.0",
-						"@jest/environment": "^24.5.0",
+						"@jest/console": "^24.7.1",
+						"@jest/environment": "^24.8.0",
 						"@jest/source-map": "^24.3.0",
-						"@jest/transform": "^24.5.0",
-						"@jest/types": "^24.5.0",
+						"@jest/transform": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"@types/yargs": "^12.0.2",
 						"chalk": "^2.0.1",
 						"exit": "^0.1.2",
 						"glob": "^7.1.3",
 						"graceful-fs": "^4.1.15",
-						"jest-config": "^24.5.0",
-						"jest-haste-map": "^24.5.0",
-						"jest-message-util": "^24.5.0",
-						"jest-mock": "^24.5.0",
+						"jest-config": "^24.8.0",
+						"jest-haste-map": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-mock": "^24.8.0",
 						"jest-regex-util": "^24.3.0",
-						"jest-resolve": "^24.5.0",
-						"jest-snapshot": "^24.5.0",
-						"jest-util": "^24.5.0",
-						"jest-validate": "^24.5.0",
+						"jest-resolve": "^24.8.0",
+						"jest-snapshot": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-validate": "^24.8.0",
 						"realpath-native": "^1.1.0",
 						"slash": "^2.0.0",
 						"strip-bom": "^3.0.0",
@@ -5033,37 +9442,36 @@
 					"dev": true
 				},
 				"jest-snapshot": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.5.0.tgz",
-					"integrity": "sha512-eBEeJb5ROk0NcpodmSKnCVgMOo+Qsu5z9EDl3tGffwPzK1yV37mjGWF2YeIz1NkntgTzP+fUL4s09a0+0dpVWA==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
+					"integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
 					"dev": true,
 					"requires": {
 						"@babel/types": "^7.0.0",
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"chalk": "^2.0.1",
-						"expect": "^24.5.0",
-						"jest-diff": "^24.5.0",
-						"jest-matcher-utils": "^24.5.0",
-						"jest-message-util": "^24.5.0",
-						"jest-resolve": "^24.5.0",
+						"expect": "^24.8.0",
+						"jest-diff": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-resolve": "^24.8.0",
 						"mkdirp": "^0.5.1",
 						"natural-compare": "^1.4.0",
-						"pretty-format": "^24.5.0",
+						"pretty-format": "^24.8.0",
 						"semver": "^5.5.0"
 					}
 				},
 				"jest-util": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.5.0.tgz",
-					"integrity": "sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
+					"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
 					"dev": true,
 					"requires": {
-						"@jest/console": "^24.3.0",
-						"@jest/fake-timers": "^24.5.0",
+						"@jest/console": "^24.7.1",
+						"@jest/fake-timers": "^24.8.0",
 						"@jest/source-map": "^24.3.0",
-						"@jest/test-result": "^24.5.0",
-						"@jest/types": "^24.5.0",
-						"@types/node": "*",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
 						"callsites": "^3.0.0",
 						"chalk": "^2.0.1",
 						"graceful-fs": "^4.1.15",
@@ -5078,30 +9486,35 @@
 							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
 							"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
 							"dev": true
+						},
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"dev": true
 						}
 					}
 				},
 				"jest-validate": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
-					"integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
+					"integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"camelcase": "^5.0.0",
 						"chalk": "^2.0.1",
-						"jest-get-type": "^24.3.0",
+						"jest-get-type": "^24.8.0",
 						"leven": "^2.1.0",
-						"pretty-format": "^24.5.0"
+						"pretty-format": "^24.8.0"
 					}
 				},
 				"jest-worker": {
-					"version": "24.4.0",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
-					"integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
+					"version": "24.6.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+					"integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
 					"dev": true,
 					"requires": {
-						"@types/node": "*",
 						"merge-stream": "^1.0.1",
 						"supports-color": "^6.1.0"
 					},
@@ -5117,6 +9530,16 @@
 						}
 					}
 				},
+				"js-yaml": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
 				"json-schema-traverse": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5124,9 +9547,9 @@
 					"dev": true
 				},
 				"kleur": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.2.tgz",
-					"integrity": "sha512-3h7B2WRT5LNXOtQiAaWonilegHcPSf9nLVXlSTci8lu1dZUuui61+EsPEZqSVxY7rXYmB2DVKMQILxaO5WL61Q==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+					"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 					"dev": true
 				},
 				"load-json-file": {
@@ -5153,6 +9576,13 @@
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
 				},
+				"nan": {
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+					"dev": true,
+					"optional": true
+				},
 				"path-type": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -5169,21 +9599,21 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "24.5.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
-					"integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+					"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^24.5.0",
+						"@jest/types": "^24.8.0",
 						"ansi-regex": "^4.0.0",
 						"ansi-styles": "^3.2.0",
 						"react-is": "^16.8.4"
 					}
 				},
 				"prompts": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.3.tgz",
-					"integrity": "sha512-H8oWEoRZpybm6NV4to9/1limhttEo13xK62pNvn2JzY0MA03p7s0OjtmhXyon3uJmxiJJVSuUwEJFFssI3eBiQ==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
+					"integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
 					"dev": true,
 					"requires": {
 						"kleur": "^3.0.2",
@@ -5200,6 +9630,12 @@
 						"normalize-package-data": "^2.3.2",
 						"path-type": "^3.0.0"
 					}
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
 				},
 				"resolve-from": {
 					"version": "4.0.0",
@@ -5241,9 +9677,9 @@
 					}
 				},
 				"semver": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				},
 				"sisteransi": {
@@ -5256,12 +9692,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
 					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"strip-bom": {
@@ -5280,15 +9710,15 @@
 					}
 				},
 				"test-exclude": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
-					"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+					"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
 					"dev": true,
 					"requires": {
-						"arrify": "^1.0.1",
+						"glob": "^7.1.3",
 						"minimatch": "^3.0.4",
 						"read-pkg-up": "^4.0.0",
-						"require-main-filename": "^1.0.1"
+						"require-main-filename": "^2.0.0"
 					},
 					"dependencies": {
 						"read-pkg-up": {
@@ -5450,9 +9880,9 @@
 			"dev": true
 		},
 		"agent-base": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-			"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
 			"dev": true,
 			"requires": {
 				"es6-promisify": "^5.0.0"
@@ -7213,27 +11643,27 @@
 			}
 		},
 		"character-entities": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
-			"integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+			"integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==",
 			"dev": true
 		},
 		"character-entities-html4": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
-			"integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
+			"integrity": "sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg==",
 			"dev": true
 		},
 		"character-entities-legacy": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
-			"integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+			"integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==",
 			"dev": true
 		},
 		"character-reference-invalid": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
-			"integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+			"integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==",
 			"dev": true
 		},
 		"chardet": {
@@ -7243,9 +11673,9 @@
 			"dev": true
 		},
 		"check-node-version": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.2.0.tgz",
-			"integrity": "sha512-mJu4dADRf+NUeOyGgFTXaLtjyyffD3Eej2RA9IEk1CdHmoVurErLD++e/Ps6uKfsB273ky+0Z9NlOiuplxuNdw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.3.0.tgz",
+			"integrity": "sha512-OAtp7prQf+8YYKn2UB/fK1Ppb9OT+apW56atoKYUvucYLPq69VozOY0B295okBwCKymk2cictrS3qsdcZwyfzw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.3.0",
@@ -7272,13 +11702,13 @@
 			"dev": true
 		},
 		"cheerio": {
-			"version": "1.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
-			"integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+			"version": "1.0.0-rc.3",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+			"integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
 			"dev": true,
 			"requires": {
 				"css-select": "~1.2.0",
-				"dom-serializer": "~0.1.0",
+				"dom-serializer": "~0.1.1",
 				"entities": "~1.1.1",
 				"htmlparser2": "^3.9.1",
 				"lodash": "^4.15.0",
@@ -8064,9 +12494,9 @@
 			"dev": true
 		},
 		"collapse-white-space": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
-			"integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
+			"integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==",
 			"dev": true
 		},
 		"collection-visit": {
@@ -8374,6 +12804,71 @@
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
 			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+			"dev": true
+		},
+		"core-js-compat": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.3.tgz",
+			"integrity": "sha512-EP018pVhgwsKHz3YoN1hTq49aRe+h017Kjz0NQz3nXV0cCRMvH3fLQl+vEPGr4r4J5sk4sU3tUC7U1aqTCeJeA==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.6.0",
+				"core-js-pure": "3.1.3",
+				"semver": "^6.1.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.6.1",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
+					"integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000971",
+						"electron-to-chromium": "^1.3.137",
+						"node-releases": "^1.1.21"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000973",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000973.tgz",
+					"integrity": "sha512-/F3t/Yo8LEdRSEPCmI15fLu5vepVh9UCg/9inJXF5AAfW7xRRJkbaM2ut52iRMQMnGCLQouLbFdbOA+VEFOIsg==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.147",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.147.tgz",
+					"integrity": "sha512-pHE+9S2OMXOLAze6KvKMA9Te56M5e4WIdPPPeZ2JiSNvpXkDrn9FoBot1yeeXMRClWvQGI6vj06kQFqCADrspQ==",
+					"dev": true
+				},
+				"node-releases": {
+					"version": "1.1.23",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz",
+					"integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
+					"dev": true,
+					"requires": {
+						"semver": "^5.3.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+							"dev": true
+						}
+					}
+				},
+				"semver": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+					"dev": true
+				}
+			}
+		},
+		"core-js-pure": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.3.tgz",
+			"integrity": "sha512-k3JWTrcQBKqjkjI0bkfXS0lbpWPxYuHWfMMjC1VDmzU4Q58IwSbuXSo99YO/hUHlw/EB4AlfA2PVxOGkrIq6dA==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -10150,9 +14645,9 @@
 			"dev": true
 		},
 		"enzyme": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.9.0.tgz",
-			"integrity": "sha512-JqxI2BRFHbmiP7/UFqvsjxTirWoM1HfeaJrmVSZ9a1EADKkZgdPcAuISPMpoUiHlac9J4dYt81MC5BBIrbJGMg==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.10.0.tgz",
+			"integrity": "sha512-p2yy9Y7t/PFbPoTvrWde7JIYB2ZyGC+NgTNbVEGvZ5/EyoYSr9aG/2rSbVvyNvMHEhw9/dmGUJHWtfQIEiX9pg==",
 			"dev": true,
 			"requires": {
 				"array.prototype.flat": "^1.2.1",
@@ -10179,18 +14674,19 @@
 			}
 		},
 		"enzyme-adapter-react-16": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.11.2.tgz",
-			"integrity": "sha512-2ruTTCPRb0lPuw/vKTXGVZVBZqh83MNDnakMhzxhpJcIbneEwNy2Cv0KvL97pl57/GOazJHflWNLjwWhex5AAA==",
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.14.0.tgz",
+			"integrity": "sha512-7PcOF7pb4hJUvjY7oAuPGpq3BmlCig3kxXGi2kFx0YzJHppqX1K8IIV9skT1IirxXlu8W7bneKi+oQ10QRnhcA==",
 			"dev": true,
 			"requires": {
-				"enzyme-adapter-utils": "^1.10.1",
+				"enzyme-adapter-utils": "^1.12.0",
+				"has": "^1.0.3",
 				"object.assign": "^4.1.0",
 				"object.values": "^1.1.0",
 				"prop-types": "^15.7.2",
-				"react-is": "^16.8.4",
+				"react-is": "^16.8.6",
 				"react-test-renderer": "^16.0.0-0",
-				"semver": "^5.6.0"
+				"semver": "^5.7.0"
 			},
 			"dependencies": {
 				"prop-types": {
@@ -10204,20 +14700,27 @@
 						"react-is": "^16.8.1"
 					}
 				},
+				"react-is": {
+					"version": "16.8.6",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+					"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+					"dev": true
+				},
 				"semver": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				}
 			}
 		},
 		"enzyme-adapter-utils": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.10.1.tgz",
-			"integrity": "sha512-oasinhhLoBuZsIkTe8mx0HiudtfErUtG0Ooe1FOplu/t4c9rOmyG5gtrBASK6u4whHIRWvv0cbZMElzNTR21SA==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz",
+			"integrity": "sha512-wkZvE0VxcFx/8ZsBw0iAbk3gR1d9hK447ebnSYBf95+r32ezBq+XDSAvRErkc4LZosgH8J7et7H7/7CtUuQfBA==",
 			"dev": true,
 			"requires": {
+				"airbnb-prop-types": "^2.13.2",
 				"function.prototype.name": "^1.1.0",
 				"object.assign": "^4.1.0",
 				"object.fromentries": "^2.0.0",
@@ -10225,6 +14728,24 @@
 				"semver": "^5.6.0"
 			},
 			"dependencies": {
+				"airbnb-prop-types": {
+					"version": "2.13.2",
+					"resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz",
+					"integrity": "sha512-2FN6DlHr6JCSxPPi25EnqGaXC4OC3/B3k1lCd6MMYrZ51/Gf/1qDfaR+JElzWa+Tl7cY2aYOlsYJGFeQyVHIeQ==",
+					"dev": true,
+					"requires": {
+						"array.prototype.find": "^2.0.4",
+						"function.prototype.name": "^1.1.0",
+						"has": "^1.0.3",
+						"is-regex": "^1.0.4",
+						"object-is": "^1.0.1",
+						"object.assign": "^4.1.0",
+						"object.entries": "^1.1.0",
+						"prop-types": "^15.7.2",
+						"prop-types-exact": "^1.2.0",
+						"react-is": "^16.8.6"
+					}
+				},
 				"prop-types": {
 					"version": "15.7.2",
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -10236,10 +14757,16 @@
 						"react-is": "^16.8.1"
 					}
 				},
+				"react-is": {
+					"version": "16.8.6",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+					"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+					"dev": true
+				},
 				"semver": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				}
 			}
@@ -10778,6 +15305,12 @@
 				"resolve": "^1.9.0"
 			}
 		},
+		"eslint-plugin-react-hooks": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz",
+			"integrity": "sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==",
+			"dev": true
+		},
 		"eslint-scope": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
@@ -11037,9 +15570,9 @@
 			}
 		},
 		"expect-puppeteer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-4.1.0.tgz",
-			"integrity": "sha512-X6hn3xujENCtwCZL73qqqfNZFgJZSAHEd4kfx5gpYkkyXf8ltIhu2+Bj8Cu4akSW1izrwoXWQ0YEqqMhgC7K7Q==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-4.1.1.tgz",
+			"integrity": "sha512-xNpu6uYJL9Qrrp4Z31MOpDWK68zAi+2qg5aMQlyOTVZNy7cAgBZiPvKCN0C1JmP3jgPZfcxhetVjZLaw/KcJOQ==",
 			"dev": true
 		},
 		"express": {
@@ -11456,15 +15989,14 @@
 			}
 		},
 		"find-process": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.2.1.tgz",
-			"integrity": "sha512-z4RXYStNAcoi4+smpKbzJXbMT8DdvwqTE7wL7DWZMD0SkTRfQ49z9S7YaK24kuRseKr23YSZlnyL/TaJZtgM1g==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.1.tgz",
+			"integrity": "sha512-RkYWDeukxEoDKUyocqMGKAYuwhSwq77zL99gCqhX9czWon3otdlzihJ0MSZ6YWNKHyvS/MN2YR4+RGYOuIEANg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"commander": "^2.11.0",
-				"debug": "^2.6.8",
-				"lodash": "^4.17.11"
+				"debug": "^2.6.8"
 			},
 			"dependencies": {
 				"debug": {
@@ -12558,9 +17090,9 @@
 			"dev": true
 		},
 		"gonzales-pe": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.3.tgz",
-			"integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.4.tgz",
+			"integrity": "sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==",
 			"dev": true,
 			"requires": {
 				"minimist": "1.1.x"
@@ -12914,9 +17446,9 @@
 			"dev": true
 		},
 		"html-element-map": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.0.tgz",
-			"integrity": "sha512-/SP6aOiM5Ai9zALvCxDubIeez0LvG3qP7R9GcRDnJEP/HBmv0A8A9K0o8+HFudcFt46+i921ANjzKsjPjb7Enw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.1.tgz",
+			"integrity": "sha512-BZSfdEm6n706/lBfXKWa4frZRZcT5k1cOusw95ijZsHlI+GdgY0v95h6IzO3iIDf2ROwq570YTwqNPqHcNMozw==",
 			"dev": true,
 			"requires": {
 				"array-filter": "^1.0.0"
@@ -13526,9 +18058,9 @@
 			}
 		},
 		"is-alphabetical": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
-			"integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+			"integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
 			"dev": true
 		},
 		"is-alphanumeric": {
@@ -13538,9 +18070,9 @@
 			"dev": true
 		},
 		"is-alphanumerical": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
-			"integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+			"integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
 			"dev": true,
 			"requires": {
 				"is-alphabetical": "^1.0.0",
@@ -13633,9 +18165,9 @@
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 		},
 		"is-decimal": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
-			"integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+			"integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==",
 			"dev": true
 		},
 		"is-descriptor": {
@@ -13716,9 +18248,9 @@
 			}
 		},
 		"is-hexadecimal": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
-			"integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+			"integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
 			"dev": true
 		},
 		"is-installed-globally": {
@@ -13934,9 +18466,9 @@
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
 		},
 		"is-whitespace-character": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
-			"integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
+			"integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
 			"dev": true
 		},
 		"is-windows": {
@@ -13945,9 +18477,9 @@
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"is-word-character": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
-			"integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
+			"integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
 			"dev": true
 		},
 		"is-wsl": {
@@ -14593,18 +19125,18 @@
 			}
 		},
 		"jest-dev-server": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-4.0.0.tgz",
-			"integrity": "sha512-tq3fHPM8BDbu/71yIxgGgZW62s1Em6rLNDce0/ff/4No093OyjUEPM8yIUaoBt4pxwwRGkaS1EZB5PzCmRLGkg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-4.2.0.tgz",
+			"integrity": "sha512-Hy4+Y3awthvT3OI7exmqqXmselI6pvYiAQeob2hkHLtvhpsA2rO7GDPbOwxDMjqAVGUEopQOzQm37WjfB5tWdg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
 				"cwd": "^0.10.0",
-				"find-process": "^1.2.1",
-				"inquirer": "^6.2.2",
+				"find-process": "^1.4.1",
+				"prompts": "^2.0.4",
 				"spawnd": "^4.0.0",
 				"tree-kill": "^1.2.1",
-				"wait-port": "^0.2.2"
+				"wait-on": "^3.2.0"
 			},
 			"dependencies": {
 				"chalk": {
@@ -14617,6 +19149,28 @@
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
 					}
+				},
+				"kleur": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+					"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+					"dev": true
+				},
+				"prompts": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
+					"integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
+					"dev": true,
+					"requires": {
+						"kleur": "^3.0.2",
+						"sisteransi": "^1.0.0"
+					}
+				},
+				"sisteransi": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+					"integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "5.5.0",
@@ -14682,14 +19236,14 @@
 			}
 		},
 		"jest-environment-puppeteer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-4.1.0.tgz",
-			"integrity": "sha512-Usq/T0W+BcnWZ59Hyrs7KA2917NDJt+navI9hTv96CspEkyLef3TaWtmL84EXmY14C0fBa+r2efwLgtrRwPAcg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-4.2.0.tgz",
+			"integrity": "sha512-i3HC+BsB0l9LR79+wrnyz7ImomZdwgpu1QH/9l1DnOgAuD5tTIwvzbyQp1nX+z5aKUhAVhontDIvHaM4oHRQ0Q==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
 				"cwd": "^0.10.0",
-				"jest-dev-server": "^4.0.0",
+				"jest-dev-server": "^4.2.0",
 				"merge-deep": "^3.0.2"
 			},
 			"dependencies": {
@@ -14985,13 +19539,13 @@
 			"dev": true
 		},
 		"jest-puppeteer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-4.1.0.tgz",
-			"integrity": "sha512-dCHU2XbrxuykPa38x5fixN/KS/zO2OIYZeORtuf0SvuIAPPbCfj/RBfVV55FCuPkp+PmAEJJjnIF0rVBe5B2qg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-4.2.0.tgz",
+			"integrity": "sha512-vTynE0pLia0SxbE4eRdFMWAVCm75poMTKzPhKQdQ5iS7e+mZOuMtVRNXqErsHppl4+3cRnN/r3u0g6iFSvR/sw==",
 			"dev": true,
 			"requires": {
-				"expect-puppeteer": "^4.1.0",
-				"jest-environment-puppeteer": "^4.1.0"
+				"expect-puppeteer": "^4.1.1",
+				"jest-environment-puppeteer": "^4.2.0"
 			}
 		},
 		"jest-regex-util": {
@@ -16278,9 +20832,9 @@
 			"integrity": "sha1-lyHXiLR+C8taJMLivuGg2lXatRQ="
 		},
 		"longest-streak": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
-			"integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
+			"integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
 			"dev": true
 		},
 		"loose-envify": {
@@ -16392,15 +20946,15 @@
 			}
 		},
 		"markdown-escapes": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
-			"integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
+			"integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
 			"dev": true
 		},
 		"markdown-table": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
-			"integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+			"integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
 			"dev": true
 		},
 		"matcher": {
@@ -16419,9 +20973,9 @@
 			"dev": true
 		},
 		"mathml-tag-names": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.0.tgz",
-			"integrity": "sha512-3Zs9P/0zzwTob2pdgT0CHZuMbnSUSp8MB1bddfm+HDmnFWHGT4jvEZRf+2RuPoa+cjdn/z25SEt5gFTqdhvJAg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
+			"integrity": "sha512-pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==",
 			"dev": true
 		},
 		"md5.js": {
@@ -16436,9 +20990,9 @@
 			}
 		},
 		"mdast-util-compact": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.2.tgz",
-			"integrity": "sha512-d2WS98JSDVbpSsBfVvD9TaDMlqPRz7ohM/11G0rp5jOBb5q96RJ6YLszQ/09AAixyzh23FeIpCGqfaamEADtWg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
+			"integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
 			"dev": true,
 			"requires": {
 				"unist-util-visit": "^1.1.0"
@@ -17052,9 +21606,9 @@
 			"dev": true
 		},
 		"npm-package-json-lint": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-3.6.0.tgz",
-			"integrity": "sha512-N1y3r0l0oN7mYnMfRzZvYF8+NvjIx+zkskRn3J7ofipJKGH4RDDKdEGP/mV1Crf5W8uUo3201VhJe04Q+v9erw==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-3.6.1.tgz",
+			"integrity": "sha512-JltYVrBTRhxZ7fyG5OqxiqKE2MZUjWJVW/jCuywMpgeKXJyBHy7Je5wcCRxxERjgvpaTiPj/RFa/ZtN5/2wRYg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.9.2",
@@ -17122,9 +21676,9 @@
 					}
 				},
 				"ignore": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.5.tgz",
-					"integrity": "sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA==",
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+					"integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
 					"dev": true
 				},
 				"indent-string": {
@@ -17134,9 +21688,9 @@
 					"dev": true
 				},
 				"is-path-inside": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.0.0.tgz",
-					"integrity": "sha512-OmUXvSq+P7aI/aRbl1dzwdlyLn8vW7Nr2/11S7y/dcLLgnQ89hgYJp7tfc+A5SRid3rNCLpruOp2CAV68/iOcA==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+					"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
 					"dev": true,
 					"requires": {
 						"path-is-inside": "^1.0.2"
@@ -17264,9 +21818,9 @@
 					}
 				},
 				"semver": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				},
 				"strip-bom": {
@@ -17838,9 +22392,9 @@
 			}
 		},
 		"parse-entities": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.1.tgz",
-			"integrity": "sha512-NBWYLQm1KSoDKk7GAHyioLTvCZ5QjdH/ASBBQTD3iLiAWJXS5bg1jEWI8nIJ+vgVvsceBVBcDGRWSo0KVQBvvg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
 			"dev": true,
 			"requires": {
 				"character-entities": "^1.0.0",
@@ -18109,9 +22663,9 @@
 			}
 		},
 		"plur": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-3.0.1.tgz",
-			"integrity": "sha512-lJl0ojUynAM1BZn58Pas2WT/TXeC1+bS+UqShl0x9+49AtOn7DixRXVzaC8qrDOIxNDmepKnLuMTH7NQmkX0PA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
+			"integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
 			"dev": true,
 			"requires": {
 				"irregular-plurals": "^2.0.0"
@@ -19766,12 +24320,12 @@
 			}
 		},
 		"postcss-jsx": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.0.tgz",
-			"integrity": "sha512-/lWOSXSX5jlITCKFkuYU2WLFdrncZmjSVyNpHAunEgirZXLwI8RjU556e3Uz4mv0WVHnJA9d3JWb36lK9Yx99g==",
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.1.tgz",
+			"integrity": "sha512-xaZpy01YR7ijsFUtu5rViYCFHurFIPHir+faiOQp8g/NfTfWqZCKDhKrydQZ4d8WlSAmVdXGwLjpFbsNUI26Sw==",
 			"dev": true,
 			"requires": {
-				"@babel/core": ">=7.1.0"
+				"@babel/core": ">=7.2.2"
 			}
 		},
 		"postcss-lab-function": {
@@ -19836,9 +24390,9 @@
 			}
 		},
 		"postcss-less": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.3.tgz",
-			"integrity": "sha512-S0LYoO278GVmyT1uCgr1h95L19dkmzuJDMdpSMCtv+bj15OoJXtFX6c/2AlyL4OEOauGTC7nuqfudVd5kzFtuA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
+			"integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.14"
@@ -19867,9 +24421,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+					"version": "7.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -21747,9 +26301,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+					"version": "7.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -21896,9 +26450,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+					"version": "7.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -21955,9 +26509,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+					"version": "7.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -22995,21 +27549,27 @@
 			}
 		},
 		"react-test-renderer": {
-			"version": "16.8.4",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.4.tgz",
-			"integrity": "sha512-jQ9Tf/ilIGSr55Cz23AZ/7H3ABEdo9oy2zF9nDHZyhLHDSLKuoILxw2ifpBfuuwQvj4LCoqdru9iZf7gwFH28A==",
+			"version": "16.8.6",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
+			"integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
 			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"react-is": "^16.8.4",
-				"scheduler": "^0.13.4"
+				"react-is": "^16.8.6",
+				"scheduler": "^0.13.6"
 			},
 			"dependencies": {
+				"react-is": {
+					"version": "16.8.6",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+					"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+					"dev": true
+				},
 				"scheduler": {
-					"version": "0.13.4",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.4.tgz",
-					"integrity": "sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==",
+					"version": "0.13.6",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+					"integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
 					"dev": true,
 					"requires": {
 						"loose-envify": "^1.1.0",
@@ -24711,9 +29271,9 @@
 			"dev": true
 		},
 		"state-toggle": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
-			"integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
+			"integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
 			"dev": true
 		},
 		"static-extend": {
@@ -25126,14 +29686,14 @@
 					"dev": true
 				},
 				"globby": {
-					"version": "9.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-9.1.0.tgz",
-					"integrity": "sha512-VtYjhHr7ncls724Of5W6Kaahz0ag7dB4G62/2HsN+xEKG6SrPzM1AJMerGxQTwJGnN9reeyxdvXbuZYpfssCvg==",
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+					"integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
 					"dev": true,
 					"requires": {
 						"@types/glob": "^7.1.1",
 						"array-union": "^1.0.2",
-						"dir-glob": "^2.2.1",
+						"dir-glob": "^2.2.2",
 						"fast-glob": "^2.2.6",
 						"glob": "^7.1.3",
 						"ignore": "^4.0.3",
@@ -25150,9 +29710,9 @@
 					}
 				},
 				"ignore": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.5.tgz",
-					"integrity": "sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA==",
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+					"integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
 					"dev": true
 				},
 				"import-lazy": {
@@ -25268,9 +29828,9 @@
 					"dev": true
 				},
 				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+					"version": "7.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -25374,9 +29934,9 @@
 					}
 				},
 				"strip-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
-					"integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
@@ -25421,18 +29981,18 @@
 			}
 		},
 		"stylelint-config-recommended": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.1.0.tgz",
-			"integrity": "sha512-ajMbivOD7JxdsnlS5945KYhvt7L/HwN6YeYF2BH6kE4UCLJR0YvXMf+2j7nQpJyYLZx9uZzU5G1ZOSBiWAc6yA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz",
+			"integrity": "sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA==",
 			"dev": true
 		},
 		"stylelint-config-recommended-scss": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-3.2.0.tgz",
-			"integrity": "sha512-M8BFHMRf8KNz5EQPKJd8nMCGmBd2o5coDEObfHVbEkyLDgjIf1V+U5dHjaGgvhm0zToUxshxN+Gc5wpbOOew4g==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-3.3.0.tgz",
+			"integrity": "sha512-BvuuLYwoet8JutOP7K1a8YaiENN+0HQn390eDi0SWe1h7Uhx6O3GUQ6Ubgie9b/AmHX4Btmp+ZzVGbzriFTBcA==",
 			"dev": true,
 			"requires": {
-				"stylelint-config-recommended": "^2.0.0"
+				"stylelint-config-recommended": "^2.2.0"
 			}
 		},
 		"stylelint-config-wordpress": {
@@ -25447,16 +30007,35 @@
 			}
 		},
 		"stylelint-scss": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.5.4.tgz",
-			"integrity": "sha512-hEdEOfFXVqxWcUbenBONW/cAw5cJcEDasY8tGwKNAAn1GDHoZO1ATdWpr+iIk325mPGIQqVb1sUxsRxuL70trw==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.8.0.tgz",
+			"integrity": "sha512-J55tNmxXEh/ymhz5BiscIiUcHgPmJ2Nv+0+zgnqTqdQBe1URQbrdjlAyK3xq+7i2nVpWr2wlRj25SjoonZFcHg==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.11",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-selector-parser": "^5.0.0",
+				"postcss-selector-parser": "^6.0.2",
 				"postcss-value-parser": "^3.3.1"
+			},
+			"dependencies": {
+				"cssesc": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+					"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+					"dev": true
+				},
+				"postcss-selector-parser": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+					"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+					"dev": true,
+					"requires": {
+						"cssesc": "^3.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				}
 			}
 		},
 		"sugarss": {
@@ -25491,9 +30070,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+					"version": "7.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -25916,6 +30495,17 @@
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
 		},
+		"thread-loader": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.2.tgz",
+			"integrity": "sha512-7xpuc9Ifg6WU+QYw/8uUqNdRwMD+N5gjwHKMqETrs96Qn+7BHwECpt2Brzr4HFlf4IAkZsayNhmGdbkBsTJ//w==",
+			"dev": true,
+			"requires": {
+				"loader-runner": "^2.3.1",
+				"loader-utils": "^1.1.0",
+				"neo-async": "^2.6.0"
+			}
+		},
 		"throat": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
@@ -26210,9 +30800,9 @@
 			"dev": true
 		},
 		"trim-trailing-lines": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
-			"integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+			"integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
 			"dev": true
 		},
 		"trough": {
@@ -26541,9 +31131,9 @@
 			}
 		},
 		"unherit": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
-			"integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+			"integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
 			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
@@ -26674,24 +31264,24 @@
 			}
 		},
 		"unist-util-find-all-after": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.2.tgz",
-			"integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz",
+			"integrity": "sha512-CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==",
 			"dev": true,
 			"requires": {
-				"unist-util-is": "^2.0.0"
+				"unist-util-is": "^3.0.0"
 			}
 		},
 		"unist-util-is": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
-			"integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
 			"dev": true
 		},
 		"unist-util-remove-position": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
-			"integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
+			"integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
 			"dev": true,
 			"requires": {
 				"unist-util-visit": "^1.1.0"
@@ -26704,21 +31294,21 @@
 			"dev": true
 		},
 		"unist-util-visit": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
-			"integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+			"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
 			"dev": true,
 			"requires": {
 				"unist-util-visit-parents": "^2.0.0"
 			}
 		},
 		"unist-util-visit-parents": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
-			"integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+			"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
 			"dev": true,
 			"requires": {
-				"unist-util-is": "^2.1.2"
+				"unist-util-is": "^3.0.0"
 			}
 		},
 		"universalify": {
@@ -26932,9 +31522,9 @@
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"v8-compile-cache": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
-			"integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+			"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -26997,9 +31587,9 @@
 			}
 		},
 		"vfile-location": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
-			"integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
+			"integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==",
 			"dev": true
 		},
 		"vfile-message": {
@@ -27372,9 +31962,9 @@
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.1.0.tgz",
-			"integrity": "sha512-nyDyWEs7C6DZlgvu1pR1zzJfIWSiGPbtaByZr8q+Fd2xp70FuM/8ngCJzj3Er1TYRLSFmp1F1OInbEm4DZH8NA==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.3.2.tgz",
+			"integrity": "sha512-7qvJLPKB4rRWZGjVp5U1KEjwutbDHSKboAl0IfafnrdXMrgC0tOtZbQD6Rw0u4cmpgRN4O02Fc0t8eAT+FgGzA==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.7",
@@ -27393,9 +31983,9 @@
 			},
 			"dependencies": {
 				"ws": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.0.tgz",
-					"integrity": "sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==",
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
 					"dev": true,
 					"requires": {
 						"async-limiter": "~1.0.0"
@@ -27404,9 +31994,9 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.0.tgz",
-			"integrity": "sha512-t1M7G4z5FhHKJ92WRKwZ1rtvi7rHc0NZoZRbSkol0YKl4HvcC8+DsmGDmK7MmZxHSAetHagiOsjOB6MmzC2TUw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.2.tgz",
+			"integrity": "sha512-FLkobnaJJ+03j5eplxlI0TUxhGCOdfewspIGuvDVtpOlrAuKMFC57K42Ukxqs1tn8947/PM6tP95gQc0DCzRYA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
@@ -27423,9 +32013,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
 				"decamelize": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"tar": "4.4.8"
 	},
 	"devDependencies": {
-		"@wordpress/scripts": "3.0.0",
+		"@wordpress/scripts": "3.2.1",
 		"concurrently": "4.1.0",
 		"cross-env": "5.2.0",
 		"electron": "4.0.5",


### PR DESCRIPTION
## Description

This partially addresses #137, as the updated version of `@wordpress/scripts` correctly lists LGPL as an OSS license.

